### PR TITLE
Fix binary-column data corruption (#157)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ ticket with the details. If the issue is within the base system, open an issue
 on the original project - we constantly monitor stable changes there and
 incorporate them into this fork.
 
+Features/fixes added in this fork include
+
+- fix [data corruption for binary columns](https://github.com/Shopify/ghostferry/issues/157):
+  this fix has not made it into upstream master yet.
+
 Overview of How it Works
 ------------------------
 


### PR DESCRIPTION
This commit addresses a data corruption bug in the binlog streaming
phase, where the binlog writer incorrectly propagates values in
fixed-length BINARY columns that have trailing 0s in the original value.
These trailing 0s are removed from the binlog by the SQL master and
therefore do not show up in the WHERE clause for update/delete
statements executed by the binlog writer.

NOTE: This commit requires changes to one of the vendor'ed modules in

    github.com/siddontang/go-mysql

that we patch directly in the local repo. We are working on getting
these changes into the upstream module and will need to merge these
changes once we can use the latest upstream module version.

Change-Id: Ib9c1b7308e8198f1fd38439c37f444d9a8154e6a