### PR TITLE
Fix resuming binlog streaming #156

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Features/fixes added in this fork include
 
 - fix [data corruption for binary columns](https://github.com/Shopify/ghostferry/issues/157):
   this fix has not made it into upstream master yet.
+- fix [failure to resume](https://github.com/Shopify/ghostferry/issues/156):
+  this fix has not made it into upstream master yet.
 
 Overview of How it Works
 ------------------------

--- a/ferry.go
+++ b/ferry.go
@@ -493,7 +493,7 @@ func (f *Ferry) Start() error {
 	// miss some records that are inserted between the time the
 	// DataIterator determines the range of IDs to copy and the time that
 	// the starting binlog coordinates are determined.
-	var pos siddontangmysql.Position
+	var pos BinlogPosition
 	var err error
 	if f.StateToResumeFrom != nil {
 		pos, err = f.BinlogStreamer.ConnectBinlogStreamerToMysqlFrom(f.StateToResumeFrom.MinBinlogPosition())
@@ -504,9 +504,9 @@ func (f *Ferry) Start() error {
 		return err
 	}
 
-	// If we don't set this now, there is a race condition where Ghostferry
+	// If we don't set this now, there is a race condition where ghostferry
 	// is terminated with some rows copied but no binlog events are written.
-	// This guarentees that we are able to restart from a valid location.
+	// This guarantees that we are able to restart from a valid location.
 	f.StateTracker.UpdateLastWrittenBinlogPosition(pos)
 	if f.inlineVerifier != nil {
 		f.StateTracker.UpdateLastStoredBinlogPositionForInlineVerifier(pos)
@@ -749,7 +749,7 @@ func (f *Ferry) Progress() *Progress {
 	s.Throttled = f.Throttler.Throttled()
 
 	// Binlog Progress
-	s.LastSuccessfulBinlogPos = f.BinlogStreamer.lastStreamedBinlogPosition
+	s.LastSuccessfulBinlogPos = f.BinlogStreamer.GetLastStreamedBinlogPosition()
 	s.BinlogStreamerLag = time.Now().Sub(f.BinlogStreamer.lastProcessedEventTime).Seconds()
 	s.FinalBinlogPos = f.BinlogStreamer.targetBinlogPosition
 

--- a/sharding/test/copy_filter_test.go
+++ b/sharding/test/copy_filter_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/Shopify/ghostferry"
 	"github.com/Shopify/ghostferry/sharding"
 
-	"github.com/siddontang/go-mysql/mysql"
 	"github.com/siddontang/go-mysql/replication"
 	"github.com/siddontang/go-mysql/schema"
 	"github.com/stretchr/testify/suite"
@@ -142,7 +141,7 @@ func (t *CopyFilterTestSuite) TestShardingValueTypes() {
 	}
 
 	for _, tenantId := range tenantIds {
-		dmlEvents, _ := ghostferry.NewBinlogInsertEvents(t.normalTable, t.newRowsEvent([]interface{}{1001, tenantId, "data"}), mysql.Position{})
+		dmlEvents, _ := ghostferry.NewBinlogInsertEvents(t.normalTable, t.newRowsEvent([]interface{}{1001, tenantId, "data"}), ghostferry.BinlogPosition{})
 		applicable, err := t.filter.ApplicableEvent(dmlEvents[0])
 		t.Require().Nil(err)
 		t.Require().True(applicable, fmt.Sprintf("value %t wasn't applicable", tenantId))
@@ -150,7 +149,7 @@ func (t *CopyFilterTestSuite) TestShardingValueTypes() {
 }
 
 func (t *CopyFilterTestSuite) TestInvalidShardingValueTypesErrors() {
-	dmlEvents, err := ghostferry.NewBinlogInsertEvents(t.normalTable, t.newRowsEvent([]interface{}{1001, string("1"), "data"}), mysql.Position{})
+	dmlEvents, err := ghostferry.NewBinlogInsertEvents(t.normalTable, t.newRowsEvent([]interface{}{1001, string("1"), "data"}), ghostferry.BinlogPosition{})
 	_, err = t.filter.ApplicableEvent(dmlEvents[0])
 	t.Require().Equal("parsing new sharding key: invalid type %!t(string=1)", err.Error())
 }

--- a/state_tracker.go
+++ b/state_tracker.go
@@ -5,8 +5,6 @@ import (
 	"math"
 	"sync"
 	"time"
-
-	"github.com/siddontang/go-mysql/mysql"
 )
 
 // StateTracker design
@@ -36,13 +34,13 @@ type SerializableState struct {
 
 	LastSuccessfulPaginationKeys              map[string]uint64
 	CompletedTables                           map[string]bool
-	LastWrittenBinlogPosition                 mysql.Position
-	LastStoredBinlogPositionForInlineVerifier mysql.Position
+	LastWrittenBinlogPosition                 BinlogPosition
+	LastStoredBinlogPositionForInlineVerifier BinlogPosition
 	BinlogVerifyStore                         BinlogVerifySerializedStore
 }
 
-func (s *SerializableState) MinBinlogPosition() mysql.Position {
-	nilPosition := mysql.Position{}
+func (s *SerializableState) MinBinlogPosition() BinlogPosition {
+	nilPosition := BinlogPosition{}
 	if s.LastWrittenBinlogPosition == nilPosition {
 		return s.LastStoredBinlogPositionForInlineVerifier
 	}
@@ -82,8 +80,8 @@ type StateTracker struct {
 	BinlogRWMutex *sync.RWMutex
 	CopyRWMutex   *sync.RWMutex
 
-	lastWrittenBinlogPosition                 mysql.Position
-	lastStoredBinlogPositionForInlineVerifier mysql.Position
+	lastWrittenBinlogPosition                 BinlogPosition
+	lastStoredBinlogPositionForInlineVerifier BinlogPosition
 
 	lastSuccessfulPaginationKeys map[string]uint64
 	completedTables              map[string]bool
@@ -113,14 +111,14 @@ func NewStateTrackerFromSerializedState(speedLogCount int, serializedState *Seri
 	return s
 }
 
-func (s *StateTracker) UpdateLastWrittenBinlogPosition(pos mysql.Position) {
+func (s *StateTracker) UpdateLastWrittenBinlogPosition(pos BinlogPosition) {
 	s.BinlogRWMutex.Lock()
 	defer s.BinlogRWMutex.Unlock()
 
 	s.lastWrittenBinlogPosition = pos
 }
 
-func (s *StateTracker) UpdateLastStoredBinlogPositionForInlineVerifier(pos mysql.Position) {
+func (s *StateTracker) UpdateLastStoredBinlogPositionForInlineVerifier(pos BinlogPosition) {
 	s.BinlogRWMutex.Lock()
 	defer s.BinlogRWMutex.Unlock()
 

--- a/status_deprecated.go
+++ b/status_deprecated.go
@@ -75,7 +75,7 @@ func FetchStatusDeprecated(f *Ferry, v Verifier) *StatusDeprecated {
 
 	status.AutomaticCutover = f.Config.AutomaticCutover
 	status.BinlogStreamerStopRequested = f.BinlogStreamer.stopRequested
-	status.LastSuccessfulBinlogPos = f.BinlogStreamer.lastStreamedBinlogPosition
+	status.LastSuccessfulBinlogPos = f.BinlogStreamer.GetLastStreamedBinlogPosition()
 	status.TargetBinlogPos = f.BinlogStreamer.targetBinlogPosition
 
 	status.Throttled = f.Throttler.Throttled()

--- a/test/go/dml_events_test.go
+++ b/test/go/dml_events_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/Shopify/ghostferry"
-	"github.com/siddontang/go-mysql/mysql"
 	"github.com/siddontang/go-mysql/replication"
 	"github.com/siddontang/go-mysql/schema"
 	"github.com/stretchr/testify/suite"
@@ -61,7 +60,7 @@ func (this *DMLEventsTestSuite) TestBinlogInsertEventGeneratesInsertQuery() {
 		},
 	}
 
-	dmlEvents, err := ghostferry.NewBinlogInsertEvents(this.sourceTable, rowsEvent, mysql.Position{})
+	dmlEvents, err := ghostferry.NewBinlogInsertEvents(this.sourceTable, rowsEvent, ghostferry.BinlogPosition{})
 	this.Require().Nil(err)
 	this.Require().Equal(2, len(dmlEvents))
 
@@ -80,7 +79,7 @@ func (this *DMLEventsTestSuite) TestBinlogInsertEventWithWrongColumnsReturnsErro
 		Rows:  [][]interface{}{{1000}},
 	}
 
-	dmlEvents, err := ghostferry.NewBinlogInsertEvents(this.sourceTable, rowsEvent, mysql.Position{})
+	dmlEvents, err := ghostferry.NewBinlogInsertEvents(this.sourceTable, rowsEvent, ghostferry.BinlogPosition{})
 	this.Require().Nil(err)
 	this.Require().Equal(1, len(dmlEvents))
 
@@ -95,7 +94,7 @@ func (this *DMLEventsTestSuite) TestBinlogInsertEventMetadata() {
 		Rows:  [][]interface{}{{1000}},
 	}
 
-	dmlEvents, err := ghostferry.NewBinlogInsertEvents(this.sourceTable, rowsEvent, mysql.Position{})
+	dmlEvents, err := ghostferry.NewBinlogInsertEvents(this.sourceTable, rowsEvent, ghostferry.BinlogPosition{})
 	this.Require().Nil(err)
 	this.Require().Equal(1, len(dmlEvents))
 	this.Require().Equal("test_schema", dmlEvents[0].Database())
@@ -115,7 +114,7 @@ func (this *DMLEventsTestSuite) TestBinlogUpdateEventGeneratesUpdateQuery() {
 		},
 	}
 
-	dmlEvents, err := ghostferry.NewBinlogUpdateEvents(this.sourceTable, rowsEvent, mysql.Position{})
+	dmlEvents, err := ghostferry.NewBinlogUpdateEvents(this.sourceTable, rowsEvent, ghostferry.BinlogPosition{})
 	this.Require().Nil(err)
 	this.Require().Equal(2, len(dmlEvents))
 
@@ -134,7 +133,7 @@ func (this *DMLEventsTestSuite) TestBinlogUpdateEventWithWrongColumnsReturnsErro
 		Rows:  [][]interface{}{{1000}, {1000}},
 	}
 
-	dmlEvents, err := ghostferry.NewBinlogUpdateEvents(this.sourceTable, rowsEvent, mysql.Position{})
+	dmlEvents, err := ghostferry.NewBinlogUpdateEvents(this.sourceTable, rowsEvent, ghostferry.BinlogPosition{})
 	this.Require().Nil(err)
 	this.Require().Equal(1, len(dmlEvents))
 
@@ -152,7 +151,7 @@ func (this *DMLEventsTestSuite) TestBinlogUpdateEventWithNull() {
 		},
 	}
 
-	dmlEvents, err := ghostferry.NewBinlogUpdateEvents(this.sourceTable, rowsEvent, mysql.Position{})
+	dmlEvents, err := ghostferry.NewBinlogUpdateEvents(this.sourceTable, rowsEvent, ghostferry.BinlogPosition{})
 	this.Require().Nil(err)
 	this.Require().Equal(1, len(dmlEvents))
 
@@ -167,7 +166,7 @@ func (this *DMLEventsTestSuite) TestBinlogUpdateEventMetadata() {
 		Rows:  [][]interface{}{{1000}, {1001}},
 	}
 
-	dmlEvents, err := ghostferry.NewBinlogUpdateEvents(this.sourceTable, rowsEvent, mysql.Position{})
+	dmlEvents, err := ghostferry.NewBinlogUpdateEvents(this.sourceTable, rowsEvent, ghostferry.BinlogPosition{})
 	this.Require().Nil(err)
 	this.Require().Equal(1, len(dmlEvents))
 	this.Require().Equal("test_schema", dmlEvents[0].Database())
@@ -185,7 +184,7 @@ func (this *DMLEventsTestSuite) TestBinlogDeleteEventGeneratesDeleteQuery() {
 		},
 	}
 
-	dmlEvents, err := ghostferry.NewBinlogDeleteEvents(this.sourceTable, rowsEvent, mysql.Position{})
+	dmlEvents, err := ghostferry.NewBinlogDeleteEvents(this.sourceTable, rowsEvent, ghostferry.BinlogPosition{})
 	this.Require().Nil(err)
 	this.Require().Equal(2, len(dmlEvents))
 
@@ -206,7 +205,7 @@ func (this *DMLEventsTestSuite) TestBinlogDeleteEventWithNull() {
 		},
 	}
 
-	dmlEvents, err := ghostferry.NewBinlogDeleteEvents(this.sourceTable, rowsEvent, mysql.Position{})
+	dmlEvents, err := ghostferry.NewBinlogDeleteEvents(this.sourceTable, rowsEvent, ghostferry.BinlogPosition{})
 	this.Require().Nil(err)
 	this.Require().Equal(1, len(dmlEvents))
 
@@ -221,7 +220,7 @@ func (this *DMLEventsTestSuite) TestBinlogDeleteEventWithWrongColumnsReturnsErro
 		Rows:  [][]interface{}{{1000}},
 	}
 
-	dmlEvents, err := ghostferry.NewBinlogDeleteEvents(this.sourceTable, rowsEvent, mysql.Position{})
+	dmlEvents, err := ghostferry.NewBinlogDeleteEvents(this.sourceTable, rowsEvent, ghostferry.BinlogPosition{})
 	this.Require().Nil(err)
 	this.Require().Equal(1, len(dmlEvents))
 
@@ -236,7 +235,7 @@ func (this *DMLEventsTestSuite) TestBinlogDeleteEventMetadata() {
 		Rows:  [][]interface{}{{1000}},
 	}
 
-	dmlEvents, err := ghostferry.NewBinlogDeleteEvents(this.sourceTable, rowsEvent, mysql.Position{})
+	dmlEvents, err := ghostferry.NewBinlogDeleteEvents(this.sourceTable, rowsEvent, ghostferry.BinlogPosition{})
 	this.Require().Nil(err)
 	this.Require().Equal(1, len(dmlEvents))
 	this.Require().Equal("test_schema", dmlEvents[0].Database())

--- a/test/go/state_tracker_test.go
+++ b/test/go/state_tracker_test.go
@@ -14,56 +14,56 @@ type StateTrackerTestSuite struct {
 
 func (s *StateTrackerTestSuite) TestMinBinlogPosition() {
 	serializedState := &ghostferry.SerializableState{
-		LastWrittenBinlogPosition: mysql.Position{
+		LastWrittenBinlogPosition: ghostferry.NewResumableBinlogPosition(mysql.Position{
 			Name: "mysql-bin.00003",
 			Pos:  4,
-		},
+		}),
 
-		LastStoredBinlogPositionForInlineVerifier: mysql.Position{
+		LastStoredBinlogPositionForInlineVerifier: ghostferry.NewResumableBinlogPosition(mysql.Position{
 			Name: "mysql-bin.00003",
 			Pos:  10,
-		},
+		}),
 	}
-	s.Require().Equal(serializedState.MinBinlogPosition(), mysql.Position{"mysql-bin.00003", 4})
+	s.Require().Equal(serializedState.MinBinlogPosition().EventPosition, mysql.Position{"mysql-bin.00003", 4})
 
 	serializedState = &ghostferry.SerializableState{
-		LastWrittenBinlogPosition: mysql.Position{
+		LastWrittenBinlogPosition: ghostferry.NewResumableBinlogPosition(mysql.Position{
 			Name: "mysql-bin.00003",
 			Pos:  4,
-		},
+		}),
 
-		LastStoredBinlogPositionForInlineVerifier: mysql.Position{
+		LastStoredBinlogPositionForInlineVerifier: ghostferry.NewResumableBinlogPosition(mysql.Position{
 			Name: "mysql-bin.00002",
 			Pos:  10,
-		},
+		}),
 	}
-	s.Require().Equal(serializedState.MinBinlogPosition(), mysql.Position{"mysql-bin.00002", 10})
+	s.Require().Equal(serializedState.MinBinlogPosition().EventPosition, mysql.Position{"mysql-bin.00002", 10})
 
 	serializedState = &ghostferry.SerializableState{
-		LastWrittenBinlogPosition: mysql.Position{
+		LastWrittenBinlogPosition: ghostferry.NewResumableBinlogPosition(mysql.Position{
 			Name: "",
 			Pos:  0,
-		},
+		}),
 
-		LastStoredBinlogPositionForInlineVerifier: mysql.Position{
+		LastStoredBinlogPositionForInlineVerifier: ghostferry.NewResumableBinlogPosition(mysql.Position{
 			Name: "mysql-bin.00002",
 			Pos:  10,
-		},
+		}),
 	}
-	s.Require().Equal(serializedState.MinBinlogPosition(), mysql.Position{"mysql-bin.00002", 10})
+	s.Require().Equal(serializedState.MinBinlogPosition().EventPosition, mysql.Position{"mysql-bin.00002", 10})
 
 	serializedState = &ghostferry.SerializableState{
-		LastStoredBinlogPositionForInlineVerifier: mysql.Position{
+		LastStoredBinlogPositionForInlineVerifier: ghostferry.NewResumableBinlogPosition(mysql.Position{
 			Name: "",
 			Pos:  0,
-		},
+		}),
 
-		LastWrittenBinlogPosition: mysql.Position{
+		LastWrittenBinlogPosition: ghostferry.NewResumableBinlogPosition(mysql.Position{
 			Name: "mysql-bin.00002",
 			Pos:  10,
-		},
+		}),
 	}
-	s.Require().Equal(serializedState.MinBinlogPosition(), mysql.Position{"mysql-bin.00002", 10})
+	s.Require().Equal(serializedState.MinBinlogPosition().EventPosition, mysql.Position{"mysql-bin.00002", 10})
 }
 
 func TestStateTrackerTestSuite(t *testing.T) {

--- a/test/integration/interrupt_resume_test.rb
+++ b/test/integration/interrupt_resume_test.rb
@@ -121,8 +121,10 @@ class InterruptResumeTest < GhostferryTestCase
 
     dumped_state = ghostferry.run_expecting_interrupt
     assert_basic_fields_exist_in_dumped_state(dumped_state)
-    assert_equal "", dumped_state["LastStoredBinlogPositionForInlineVerifier"]["Name"]
-    assert_equal 0, dumped_state["LastStoredBinlogPositionForInlineVerifier"]["Pos"]
+    assert_equal "", dumped_state["LastStoredBinlogPositionForInlineVerifier"]["EventPosition"]["Name"]
+    assert_equal 0, dumped_state["LastStoredBinlogPositionForInlineVerifier"]["EventPosition"]["Pos"]
+    assert_equal "", dumped_state["LastStoredBinlogPositionForInlineVerifier"]["ResumePosition"]["Name"]
+    assert_equal 0, dumped_state["LastStoredBinlogPositionForInlineVerifier"]["ResumePosition"]["Pos"]
   end
 
   def test_interrupt_resume_inline_verifier_with_datawriter
@@ -303,5 +305,57 @@ class InterruptResumeTest < GhostferryTestCase
 
     error_line = ghostferry.error_lines.last
     assert_equal "cutover verification failed for: gftest.test_table_1 [paginationKeys: #{chosen_id} ] ", error_line["msg"]
+  end
+
+  def test_interrupt_resume_between_consecutive_rows_events
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY, config: { verifier_type: "Inline" })
+
+    # create a series of rows-events that do not have interleaved table-map
+    # events. This is the case when multiple rows are affected in a single
+    # DML event.
+    # Since we are racing between applying rows and sending the shutdown event,
+    # we emit a whole bunch of them
+    num_batches = 5
+    num_values_per_batch = 250
+    row_id = 0
+    ghostferry.on_status(Ghostferry::Status::BINLOG_STREAMING_STARTED) do
+      for _batch_id in 0..num_batches do
+        insert_sql = "INSERT INTO #{DEFAULT_FULL_TABLE_NAME} (data) VALUES "
+        for value_in_batch in 0..num_values_per_batch do
+          row_id += 1
+          insert_sql += ", " if value_in_batch > 0
+          insert_sql += "('data#{row_id}')"
+        end
+        source_db.query(insert_sql)
+      end
+    end
+
+    ghostferry.on_status(Ghostferry::Status::AFTER_BINLOG_APPLY) do
+      # while we are emitting events in the loop above, try to inject a shutdown
+      # signal, hoping to interrupt between applying an INSERT and receiving the
+      # next table-map event
+      if row_id > 20
+        ghostferry.term_and_wait_for_exit
+      end
+    end
+
+    dumped_state = ghostferry.run_expecting_interrupt
+
+    # We can verify if the race occurred (and we successfully worked around it)
+    # by looking at the dumped state (the LastWrittenBinlogPosition field should
+    # have different EventPosition and ResumePosition values).
+    #
+    # If this starts to make the test unreliable, we may want to remove this or
+    # further tweak the batch values.
+    resume_state = dumped_state["LastWrittenBinlogPosition"]
+    refute_equal resume_state["EventPosition"], resume_state["ResumePosition"]
+
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY)
+    # if we did not resume at a proper state, this invocation of ghostferry
+    # will crash, complaining that a rows-event is referring to an unknown
+    # table
+    ghostferry.run(dumped_state)
+
+    assert_test_table_is_identical
   end
 end


### PR DESCRIPTION
A mysql replication event for changing data is always started by
sending a TableMapEvent (describing the table to be changed),
followed by one or more RowsEvent (containing the data to be
changed). If multiple consecutive RowsEvent events are sent for the
same table, the TableMapEvent is typically skipped (after sending it
once), meaning that resuming from such a binlog is not possible.

Resuming at a binlog position between the TableMapEvent and a
RowsEvent is not possible, as the binlog streamer would miss the
table definition for following DML statements.

This commit tracks the position of the most recently processed
TableMapEvent and uses this for resuming (skipping any actual events
between the last write and resume position that were already
processed).

Change-Id: I2bef401ba4f1c0d5f50f177f48c2e866bb411f5d