### PR TITLE
Support copying tables without "paging" keys #162

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ Features/fixes added in this fork include
   migrating such databases and the feature must be used with great care.
   Especially the use of database- or table-rewrites may introduce invalid target
   database states that are not recoverable.
+- support [copying tables without "paging" primary keys](https://github.com/Shopify/ghostferry/issues/162):
+  `Ghostferry` requires integer auto-increment primary keys for copying data.
+  An optional feature in this fork allows marking tables for "full copy",
+  allowing to copy tables that do not meet this primary key requirement. It is
+  **strongly recommended** to use this feature with care and only on tables with
+  few rows, as the copy process requires locking the entire table on the source
+  database.
 
 Overview of How it Works
 ------------------------

--- a/batch_writer.go
+++ b/batch_writer.go
@@ -35,23 +35,8 @@ func (w *BatchWriter) Initialize() {
 	w.logger = logrus.WithField("tag", "batch_writer")
 }
 
-func (w *BatchWriter) WriteRowBatch(batch *RowBatch) error {
+func (w *BatchWriter) WriteRowBatch(batch RowBatch) error {
 	return WithRetries(w.WriteRetries, 0, w.logger, "write batch to target", func() error {
-		values := batch.Values()
-		if len(values) == 0 {
-			return nil
-		}
-
-		startPaginationKeypos, err := values[0].GetUint64(batch.PaginationKeyIndex())
-		if err != nil {
-			return err
-		}
-
-		endPaginationKeypos, err := values[len(values)-1].GetUint64(batch.PaginationKeyIndex())
-		if err != nil {
-			return err
-		}
-
 		db := batch.TableSchema().Schema
 		if targetDbName, exists := w.DatabaseRewrites[db]; exists {
 			db = targetDbName
@@ -62,52 +47,117 @@ func (w *BatchWriter) WriteRowBatch(batch *RowBatch) error {
 			table = targetTableName
 		}
 
-		query, args, err := batch.AsSQLQuery(db, table)
-		if err != nil {
-			return fmt.Errorf("during generating sql query at paginationKey %v -> %v: %v", startPaginationKeypos, endPaginationKeypos, err)
+		switch b := batch.(type) {
+		case InsertRowBatch:
+			return w.writeInsertRowBatch(b, db, table)
+		// NOTE: It's important we check this last, as the interface
+		// is (currently) indistinguishable from a plain RowBatch
+		case InitRowBatch:
+			return w.writeInitRowBatch(b, db, table)
+		default:
+			// see above, we can actually never get here right now
+			return fmt.Errorf("unsupported row-batch type %T", batch)
 		}
-
-		stmt, err := w.stmtCache.StmtFor(w.DB, query)
-		if err != nil {
-			return fmt.Errorf("during prepare query near paginationKey %v -> %v (%s): %v", startPaginationKeypos, endPaginationKeypos, query, err)
-		}
-
-		tx, err := w.DB.Begin()
-		if err != nil {
-			return fmt.Errorf("unable to begin transaction in BatchWriter: %v", err)
-		}
-
-		_, err = tx.Stmt(stmt).Exec(args...)
-		if err != nil {
-			tx.Rollback()
-			return fmt.Errorf("during exec query near paginationKey %v -> %v (%s): %v", startPaginationKeypos, endPaginationKeypos, query, err)
-		}
-
-		if w.InlineVerifier != nil {
-			mismatches, err := w.InlineVerifier.CheckFingerprintInline(tx, db, table, batch)
-			if err != nil {
-				tx.Rollback()
-				return fmt.Errorf("during fingerprint checking for paginationKey %v -> %v (%s): %v", startPaginationKeypos, endPaginationKeypos, query, err)
-			}
-
-			if len(mismatches) > 0 {
-				tx.Rollback()
-				return BatchWriterVerificationFailed{mismatches, batch.TableSchema().String()}
-			}
-		}
-
-		err = tx.Commit()
-		if err != nil {
-			tx.Rollback()
-			return fmt.Errorf("during commit near paginationKey %v -> %v (%s): %v", startPaginationKeypos, endPaginationKeypos, query, err)
-		}
-
-		// Note that the state tracker expects us the track based on the original
-		// database and table names as opposed to the target ones.
-		if w.StateTracker != nil {
-			w.StateTracker.UpdateLastSuccessfulPaginationKey(batch.TableSchema().String(), endPaginationKeypos)
-		}
-
-		return nil
 	})
+}
+
+func (w *BatchWriter) writeInsertRowBatch(batch InsertRowBatch, db, table string) error {
+	values := batch.Values()
+	if len(values) == 0 {
+		return nil
+	}
+
+	var startPaginationKeypos, endPaginationKeypos uint64
+	var err error
+	if batch.ValuesContainPaginationKey() {
+		index := batch.PaginationKeyIndex()
+		startPaginationKeypos, err = values[0].GetUint64(index)
+		if err != nil {
+			return err
+		}
+
+		endPaginationKeypos, err = values[len(values)-1].GetUint64(index)
+		if err != nil {
+			return err
+		}
+	}
+
+	query, args, err := batch.AsSQLQuery(db, table)
+	if err != nil {
+		return fmt.Errorf("during generating sql query at paginationKey %v -> %v: %v", startPaginationKeypos, endPaginationKeypos, err)
+	}
+
+	stmt, err := w.stmtCache.StmtFor(w.DB, query)
+	if err != nil {
+		return fmt.Errorf("during prepare query near paginationKey %v -> %v (%s): %v", startPaginationKeypos, endPaginationKeypos, query, err)
+	}
+
+	tx, err := w.DB.Begin()
+	if err != nil {
+		return fmt.Errorf("unable to begin transaction in BatchWriter: %v", err)
+	}
+
+	_, err = tx.Stmt(stmt).Exec(args...)
+	if err != nil {
+		tx.Rollback()
+		return fmt.Errorf("during exec query near paginationKey %v -> %v (%s): %v", startPaginationKeypos, endPaginationKeypos, query, err)
+	}
+
+	if w.InlineVerifier != nil {
+		mismatches, err := w.InlineVerifier.CheckFingerprintInline(tx, db, table, batch)
+		if err != nil {
+			tx.Rollback()
+			return fmt.Errorf("during fingerprint checking for paginationKey %v -> %v (%s): %v", startPaginationKeypos, endPaginationKeypos, query, err)
+		}
+
+		if len(mismatches) > 0 {
+			tx.Rollback()
+			return BatchWriterVerificationFailed{mismatches, batch.TableSchema().String()}
+		}
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		tx.Rollback()
+		return fmt.Errorf("during commit near paginationKey %v -> %v (%s): %v", startPaginationKeypos, endPaginationKeypos, query, err)
+	}
+
+	// Note that the state tracker expects us the track based on the original
+	// database and table names as opposed to the target ones.
+	if w.StateTracker != nil {
+		w.StateTracker.UpdateLastSuccessfulPaginationKey(batch.TableSchema().String(), endPaginationKeypos)
+	}
+
+	return nil
+}
+
+func (w *BatchWriter) writeInitRowBatch(batch InitRowBatch, db, table string) error {
+	query, args, err := batch.AsSQLQuery(db, table)
+	if err != nil {
+		return fmt.Errorf("during generating sql init query: %v", err)
+	}
+
+	stmt, err := w.stmtCache.StmtFor(w.DB, query)
+	if err != nil {
+		return fmt.Errorf("during prepare init query (%s): %v", query, err)
+	}
+
+	tx, err := w.DB.Begin()
+	if err != nil {
+		return fmt.Errorf("unable to begin transaction in BatchWriter: %v", err)
+	}
+
+	_, err = tx.Stmt(stmt).Exec(args...)
+	if err != nil {
+		tx.Rollback()
+		return fmt.Errorf("during exec init query (%s): %v", query, err)
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		tx.Rollback()
+		return fmt.Errorf("during init commit (%s): %v", query, err)
+	}
+
+	return nil
 }

--- a/config.go
+++ b/config.go
@@ -273,11 +273,32 @@ func (c ColumnIgnoreConfig) IgnoredColumnsFor(schemaName, tableName string) map[
 // precedence.
 type CascadingPaginationColumnConfig struct {
 	// PerTable has greatest specificity and takes precedence over the other options
+	FullTableCopies map[string][]string // SchemaName => TableNames
+
+	// PerTable has next greatest specificity and takes precedence over the other options
 	PerTable map[string]map[string]string // SchemaName => TableName => ColumnName
 
 	// FallbackColumn is a global default to fallback to and is less specific than the
 	// default, which is the Primary Key
 	FallbackColumn string
+}
+
+func (c *CascadingPaginationColumnConfig) IsFullCopyTable(schemaName, tableName string) bool {
+	if c == nil {
+		return false
+	}
+
+	tableConfig, found := c.FullTableCopies[schemaName]
+	if !found {
+		return false
+	}
+
+	for _, table := range tableConfig {
+		if table == tableName {
+			return true
+		}
+	}
+	return false
 }
 
 // PaginationColumnFor is a helper function to retrieve the column name to paginate by
@@ -475,9 +496,10 @@ type Config struct {
 	IgnoredColumnsForVerification ColumnIgnoreConfig
 
 	// Ghostferry requires a single numeric column to paginate over tables. Inferring that column is done in the following exact order:
-	// 1. Use the PerTable pagination column, if configured for a table. Fail if we cannot find this column in the table.
-	// 2. Use the table's primary key column as the pagination column. Fail if the primary key is not numeric or is a composite key without a FallbackColumn specified.
-	// 3. Use the FallbackColumn pagination column, if configured. Fail if we cannot find this column in the table.
+	// 1. Find the table in the FullCopyTables list and perform non-paginated copies (only reasonable for small tables).
+	// 2. Use the PerTable pagination column, if configured for a table. Fail if we cannot find this column in the table.
+	// 3. Use the table's primary key column as the pagination column. Fail if the primary key is not numeric or is a composite key without a FallbackColumn specified.
+	// 4. Use the FallbackColumn pagination column, if configured. Fail if we cannot find this column in the table.
 	CascadingPaginationColumnConfig *CascadingPaginationColumnConfig
 }
 

--- a/data_iterator.go
+++ b/data_iterator.go
@@ -19,7 +19,7 @@ type DataIterator struct {
 	StateTracker *StateTracker
 
 	targetPaginationKeys *sync.Map
-	batchListeners       []func(*RowBatch) error
+	batchListeners       []func(RowBatch) error
 	doneListeners        []func() error
 	logger               *logrus.Entry
 }
@@ -36,108 +36,59 @@ func (d *DataIterator) Run(tables []*TableSchema) {
 	}
 
 	d.logger.WithField("tablesCount", len(tables)).Info("starting data iterator run")
-	tablesWithData, emptyTables, err := MaxPaginationKeys(d.DB, tables, d.logger)
+	paginatedTables, unpaginatedTables, emptyTables, err := MaxPaginationKeys(d.DB, tables, d.logger)
 	if err != nil {
 		d.ErrorHandler.Fatal("data_iterator", err)
 	}
 
 	for _, table := range emptyTables {
+		d.logger.WithField("table", table.String()).Debug("table is empty, removing from copy list")
 		d.StateTracker.MarkTableAsCompleted(table.String())
 	}
 
-	for table, maxPaginationKey := range tablesWithData {
+	tmp := unpaginatedTables[:0]
+	for _, table := range unpaginatedTables {
 		tableName := table.String()
 		if d.StateTracker.IsTableComplete(tableName) {
 			// In a previous run, the table may have been completed.
 			// We don't need to reiterate those tables as it has already been done.
-			delete(tablesWithData, table)
+			d.logger.WithField("table", tableName).Debug("table already copied completely, removing from unpaginagted table copy list")
+		} else {
+			tmp = append(tmp, table)
+		}
+	}
+	unpaginatedTables = tmp
+
+	for table, maxPaginationKey := range paginatedTables {
+		tableName := table.String()
+		if d.StateTracker.IsTableComplete(tableName) {
+			// In a previous run, the table may have been completed.
+			// We don't need to reiterate those tables as it has already been done.
+			d.logger.WithField("table", tableName).Debug("table already copied completely, removing from paginagted table copy list")
+			delete(paginatedTables, table)
 		} else {
 			d.targetPaginationKeys.Store(table.String(), maxPaginationKey)
 		}
 	}
 
-	tablesQueue := make(chan *TableSchema)
+	paginatedTablesQueue := make(chan *TableSchema)
+	unpaginatedTablesQueue := make(chan *TableSchema)
 	wg := &sync.WaitGroup{}
-	wg.Add(d.Concurrency)
+	wg.Add(d.Concurrency + 1)
 
 	for i := 0; i < d.Concurrency; i++ {
 		go func() {
 			defer wg.Done()
 
 			for {
-				table, ok := <-tablesQueue
+				table, ok := <-paginatedTablesQueue
 				if !ok {
 					break
 				}
 
-				logger := d.logger.WithField("table", table.String())
-
-				targetPaginationKeyInterface, found := d.targetPaginationKeys.Load(table.String())
-				if !found {
-					err := fmt.Errorf("%s not found in targetPaginationKeys, this is likely a programmer error", table.String())
-					logger.WithError(err).Error("this is definitely a bug")
-					d.ErrorHandler.Fatal("data_iterator", err)
-					return
-				}
-
-				startPaginationKey := d.StateTracker.LastSuccessfulPaginationKey(table.String())
-				if startPaginationKey == math.MaxUint64 {
-					err := fmt.Errorf("%v has been marked as completed but a table iterator has been spawned, this is likely a programmer error which resulted in the inconsistent starting state", table.String())
-					logger.WithError(err).Error("this is definitely a bug")
-					d.ErrorHandler.Fatal("data_iterator", err)
-					return
-				}
-
-				cursor := d.CursorConfig.NewCursor(table, startPaginationKey, targetPaginationKeyInterface.(uint64))
-				if d.SelectFingerprint {
-					if len(cursor.ColumnsToSelect) == 0 {
-						cursor.ColumnsToSelect = []string{"*"}
-					}
-
-					cursor.ColumnsToSelect = append(cursor.ColumnsToSelect, table.RowMd5Query())
-				}
-
-				err := cursor.Each(func(batch *RowBatch) error {
-					metrics.Count("RowEvent", int64(batch.Size()), []MetricTag{
-						MetricTag{"table", table.Name},
-						MetricTag{"source", "table"},
-					}, 1.0)
-
-					if d.SelectFingerprint {
-						fingerprints := make(map[uint64][]byte)
-						rows := make([]RowData, batch.Size())
-
-						for i, rowData := range batch.Values() {
-							paginationKey, err := rowData.GetUint64(batch.PaginationKeyIndex())
-							if err != nil {
-								logger.WithError(err).Error("failed to get paginationKey data")
-								return err
-							}
-
-							fingerprints[paginationKey] = rowData[len(rowData)-1].([]byte)
-							rows[i] = rowData[:len(rowData)-1]
-						}
-
-						batch = &RowBatch{
-							values:             rows,
-							paginationKeyIndex: batch.PaginationKeyIndex(),
-							table:              table,
-							fingerprints:       fingerprints,
-						}
-					}
-
-					for _, listener := range d.batchListeners {
-						err := listener(batch)
-						if err != nil {
-							logger.WithError(err).Error("failed to process row batch with listeners")
-							return err
-						}
-					}
-
-					return nil
-				})
-
+				err = d.processPaginatedTable(table)
 				if err != nil {
+					logger := d.logger.WithField("table", table.String())
 					switch e := err.(type) {
 					case BatchWriterVerificationFailed:
 						logger.WithField("incorrect_tables", e.table).Error(e.Error())
@@ -146,43 +97,177 @@ func (d *DataIterator) Run(tables []*TableSchema) {
 						logger.WithError(err).Error("failed to iterate table")
 						d.ErrorHandler.Fatal("data_iterator", err)
 					}
-
 				}
-
-				logger.Debug("table iteration completed")
-
-				// Right now the BatchWriter.WriteRowBatch happens synchronously in
-				// this method. If it ever becomes async, this MarkTableAsCompleted
-				// call MUST be done in WriteRowBatch somehow.
-				d.StateTracker.MarkTableAsCompleted(table.String())
 			}
 		}()
 	}
 
+	// NOTE: We don't run full-table copies in parallel. These are meant for
+	// small-ish tables and should be kept short (due to full-table locking
+	// on the source)
+	go func() {
+		defer wg.Done()
+
+		for {
+			table, ok := <-unpaginatedTablesQueue
+			if !ok {
+				break
+			}
+
+			err := d.processUnpaginatedTable(table)
+			if err != nil {
+				d.ErrorHandler.Fatal("data_iterator", err)
+			}
+		}
+	}()
+
 	i := 0
-	loggingIncrement := len(tablesWithData) / 50
+	totalTablesToCopy := len(paginatedTables) + len(unpaginatedTables)
+	loggingIncrement := totalTablesToCopy / 50
 	if loggingIncrement == 0 {
 		loggingIncrement = 1
 	}
 
-	for table, _ := range tablesWithData {
-		tablesQueue <- table
+	for table, _ := range paginatedTables {
+		paginatedTablesQueue <- table
 		i++
 		if i%loggingIncrement == 0 {
-			d.logger.WithField("table", table.String()).Infof("queued table for processing (%d/%d)", i, len(tablesWithData))
+			d.logger.WithField("table", table.String()).Infof("queued table for paginated processing (%d/%d)", i, totalTablesToCopy)
+		}
+	}
+
+	for _, table := range unpaginatedTables {
+		unpaginatedTablesQueue <- table
+		i++
+		if i%loggingIncrement == 0 {
+			d.logger.WithField("table", table.String()).Infof("queued table for full-table processing (%d/%d)", i, totalTablesToCopy)
 		}
 	}
 
 	d.logger.Info("done queueing tables to be iterated, closing table channel")
-	close(tablesQueue)
+	close(paginatedTablesQueue)
+	close(unpaginatedTablesQueue)
 
+	d.logger.Debug("waiting for table copy to complete")
 	wg.Wait()
+	d.logger.Debug("table copy completed, notifying listeners")
 	for _, listener := range d.doneListeners {
 		listener()
 	}
+	d.logger.Debug("table copy done")
 }
 
-func (d *DataIterator) AddBatchListener(listener func(*RowBatch) error) {
+func (d *DataIterator) processPaginatedTable(table *TableSchema) error {
+	logger := d.logger.WithField("table", table.String())
+
+	targetPaginationKeyInterface, found := d.targetPaginationKeys.Load(table.String())
+	if !found {
+		err := fmt.Errorf("%s not found in targetPaginationKeys, this is likely a programmer error", table.String())
+		logger.WithError(err).Error("this is definitely a bug")
+		return err
+	}
+
+	startPaginationKey := d.StateTracker.LastSuccessfulPaginationKey(table.String())
+	if startPaginationKey == math.MaxUint64 {
+		err := fmt.Errorf("%v has been marked as completed but a table iterator has been spawned, this is likely a programmer error which resulted in the inconsistent starting state", table.String())
+		logger.WithError(err).Error("this is definitely a bug")
+		return err
+	}
+
+	cursor := d.CursorConfig.NewPaginatedCursor(table, startPaginationKey, targetPaginationKeyInterface.(uint64))
+	if d.SelectFingerprint {
+		if len(cursor.ColumnsToSelect) == 0 {
+			cursor.ColumnsToSelect = []string{"*"}
+		}
+
+		cursor.ColumnsToSelect = append(cursor.ColumnsToSelect, table.RowMd5Query())
+	}
+
+	err := cursor.Each(func(batch InsertRowBatch) error {
+		metrics.Count("RowEvent", int64(batch.Size()), []MetricTag{
+			MetricTag{"table", table.Name},
+			MetricTag{"source", "table"},
+		}, 1.0)
+
+		if d.SelectFingerprint {
+			fingerprints := make(map[uint64][]byte)
+			rows := make([]RowData, batch.Size())
+
+			for i, rowData := range batch.Values() {
+				paginationKey, err := rowData.GetUint64(batch.PaginationKeyIndex())
+				if err != nil {
+					logger.WithError(err).Error("failed to get paginationKey data")
+					return err
+				}
+
+				fingerprints[paginationKey] = rowData[len(rowData)-1].([]byte)
+				rows[i] = rowData[:len(rowData)-1]
+			}
+
+			batch = &DataRowBatch{
+				values:             rows,
+				paginationKeyIndex: batch.PaginationKeyIndex(),
+				table:              table,
+				fingerprints:       fingerprints,
+			}
+		}
+
+		for _, listener := range d.batchListeners {
+			err := listener(batch)
+			if err != nil {
+				logger.WithError(err).Error("failed to process row batch with listeners")
+				return err
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	logger.Debug("table iteration completed")
+
+	// Right now the BatchWriter.WriteRowBatch happens synchronously in
+	// this method. If it ever becomes async, this MarkTableAsCompleted
+	// call MUST be done in WriteRowBatch somehow.
+	d.StateTracker.MarkTableAsCompleted(table.String())
+	return nil
+}
+
+func (d *DataIterator) processUnpaginatedTable(table *TableSchema) error {
+	logger := d.logger.WithField("table", table.String())
+	logger.Debug("Starting full-table copy")
+
+	cursor := d.CursorConfig.NewFullTableCursor(table)
+	err := cursor.Each(func(batch RowBatch) error {
+		metrics.Count("RowEvent", int64(batch.Size()), []MetricTag{
+			MetricTag{"table", table.Name},
+			MetricTag{"source", "table"},
+		}, 1.0)
+
+		for _, listener := range d.batchListeners {
+			err := listener(batch)
+			if err != nil {
+				logger.WithError(err).Error("failed to process full-table row batch with listeners")
+				return err
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		logger.WithError(err).Error("failed to scan full table")
+		return err
+	}
+
+	logger.Debug("full table scan completed")
+	d.StateTracker.MarkTableAsCompleted(table.String())
+	return nil
+}
+
+func (d *DataIterator) AddBatchListener(listener func(RowBatch) error) {
 	d.batchListeners = append(d.batchListeners, listener)
 }
 

--- a/inline_verifier.go
+++ b/inline_verifier.go
@@ -244,7 +244,7 @@ func (v *InlineVerifier) Result() (VerificationResultAndStatus, error) {
 	return VerificationResultAndStatus{}, nil
 }
 
-func (v *InlineVerifier) CheckFingerprintInline(tx *sql.Tx, targetSchema, targetTable string, sourceBatch *RowBatch) ([]uint64, error) {
+func (v *InlineVerifier) CheckFingerprintInline(tx *sql.Tx, targetSchema, targetTable string, sourceBatch InsertRowBatch) ([]uint64, error) {
 	table := sourceBatch.TableSchema()
 
 	paginationKeys := make([]uint64, len(sourceBatch.Values()))

--- a/iterative_verifier.go
+++ b/iterative_verifier.go
@@ -384,11 +384,11 @@ func (v *IterativeVerifier) iterateAllTables(mismatchedPaginationKeyFunc func(ui
 func (v *IterativeVerifier) iterateTableFingerprints(table *TableSchema, mismatchedPaginationKeyFunc func(uint64, *TableSchema) error) error {
 	// The cursor will stop iterating when it cannot find anymore rows,
 	// so it will not iterate until MaxUint64.
-	cursor := v.CursorConfig.NewCursorWithoutRowLock(table, 0, math.MaxUint64)
+	cursor := v.CursorConfig.NewPaginatedCursorWithoutRowLock(table, 0, math.MaxUint64)
 
 	// It only needs the PaginationKeys, not the entire row.
 	cursor.ColumnsToSelect = []string{fmt.Sprintf("`%s`", table.GetPaginationColumn().Name)}
-	return cursor.Each(func(batch *RowBatch) error {
+	return cursor.Each(func(batch InsertRowBatch) error {
 		metrics.Count("RowEvent", int64(batch.Size()), []MetricTag{
 			MetricTag{"table", table.Name},
 			MetricTag{"source", "iterative_verifier_before_cutover"},

--- a/row_batch.go
+++ b/row_batch.go
@@ -4,46 +4,68 @@ import (
 	"strings"
 )
 
-type RowBatch struct {
+type RowBatch interface {
+	TableSchema() *TableSchema
+	AsSQLQuery(schemaName, tableName string) (string, []interface{}, error)
+	Size() int
+}
+
+type InsertRowBatch interface {
+	RowBatch
+	Values() []RowData
+	PaginationKeyIndex() int
+	ValuesContainPaginationKey() bool
+	Fingerprints() map[uint64][]byte
+}
+
+type InitRowBatch interface {
+	RowBatch
+}
+
+type DataRowBatch struct {
 	values             []RowData
 	paginationKeyIndex int
 	table              *TableSchema
 	fingerprints       map[uint64][]byte
 }
 
-func NewRowBatch(table *TableSchema, values []RowData, paginationKeyIndex int) *RowBatch {
-	return &RowBatch{
+func NewDataRowBatch(table *TableSchema, values []RowData) *DataRowBatch {
+	return NewDataRowBatchWithPaginationKey(table, values, -1)
+}
+
+func NewDataRowBatchWithPaginationKey(table *TableSchema, values []RowData, paginationKeyIndex int) *DataRowBatch {
+	return &DataRowBatch{
 		values:             values,
 		paginationKeyIndex: paginationKeyIndex,
 		table:              table,
 	}
 }
 
-func (e *RowBatch) Values() []RowData {
+func (e *DataRowBatch) Values() []RowData {
 	return e.values
 }
 
-func (e *RowBatch) PaginationKeyIndex() int {
+func (e *DataRowBatch) PaginationKeyIndex() int {
 	return e.paginationKeyIndex
 }
 
-func (e *RowBatch) ValuesContainPaginationKey() bool {
+func (e *DataRowBatch) ValuesContainPaginationKey() bool {
 	return e.paginationKeyIndex >= 0
 }
 
-func (e *RowBatch) Size() int {
+func (e *DataRowBatch) Size() int {
 	return len(e.values)
 }
 
-func (e *RowBatch) TableSchema() *TableSchema {
+func (e *DataRowBatch) TableSchema() *TableSchema {
 	return e.table
 }
 
-func (e *RowBatch) Fingerprints() map[uint64][]byte {
+func (e *DataRowBatch) Fingerprints() map[uint64][]byte {
 	return e.fingerprints
 }
 
-func (e *RowBatch) AsSQLQuery(schemaName, tableName string) (string, []interface{}, error) {
+func (e *DataRowBatch) AsSQLQuery(schemaName, tableName string) (string, []interface{}, error) {
 	if err := verifyValuesHasTheSameLengthAsColumns(e.table, e.values...); err != nil {
 		return "", nil, err
 	}
@@ -60,7 +82,7 @@ func (e *RowBatch) AsSQLQuery(schemaName, tableName string) (string, []interface
 	return query, e.flattenRowData(), nil
 }
 
-func (e *RowBatch) flattenRowData() []interface{} {
+func (e *DataRowBatch) flattenRowData() []interface{} {
 	rowSize := len(e.values[0])
 	flattened := make([]interface{}, rowSize*len(e.values))
 
@@ -71,4 +93,26 @@ func (e *RowBatch) flattenRowData() []interface{} {
 	}
 
 	return flattened
+}
+
+type TruncateTableBatch struct {
+	table *TableSchema
+}
+
+func NewTruncateTableBatch(table *TableSchema) *TruncateTableBatch {
+	return &TruncateTableBatch{table}
+}
+
+func (e *TruncateTableBatch) TableSchema() *TableSchema {
+	return e.table
+}
+
+func (e *TruncateTableBatch) Size() int {
+	return 1
+}
+
+func (e *TruncateTableBatch) AsSQLQuery(schemaName, tableName string) (string, []interface{}, error) {
+	query := "TRUNCATE TABLE " +
+		QuotedTableNameFromString(schemaName, tableName)
+	return query, nil, nil
 }

--- a/test/go/data_iterator_test.go
+++ b/test/go/data_iterator_test.go
@@ -59,8 +59,11 @@ func (this *DataIteratorTestSuite) SetupTest() {
 
 	this.receivedRows = make(map[string][]ghostferry.RowData, 0)
 
-	this.di.AddBatchListener(func(ev *ghostferry.RowBatch) error {
-		this.receivedRows[ev.TableSchema().Name] = append(this.receivedRows[ev.TableSchema().Name], ev.Values()...)
+	this.di.AddBatchListener(func(b ghostferry.RowBatch) error {
+		switch ev := b.(type) {
+		case ghostferry.InsertRowBatch:
+			this.receivedRows[ev.TableSchema().Name] = append(this.receivedRows[ev.TableSchema().Name], ev.Values()...)
+		}
 		return nil
 	})
 }

--- a/test/go/race_conditions_integration_test.go
+++ b/test/go/race_conditions_integration_test.go
@@ -23,7 +23,12 @@ func TestSelectUpdateBinlogCopy(t *testing.T) {
 		Ferry:       testhelpers.NewTestFerry(),
 	}
 
-	testcase.Ferry.BeforeBatchCopyListener = func(batch *ghostferry.RowBatch) error {
+	testcase.Ferry.BeforeBatchCopyListener = func(rowBatch ghostferry.RowBatch) error {
+		batch, ok := rowBatch.(ghostferry.InsertRowBatch)
+		if !ok {
+			return nil
+		}
+
 		queries := make([]string, len(batch.Values()))
 		for i, row := range batch.Values() {
 			id := row[0].(int64)
@@ -138,7 +143,7 @@ func TestOnlyDeleteRowWithMaxPaginationKey(t *testing.T) {
 	testcase.Ferry.DataIterationBatchSize = 1
 
 	lastRowDeleted := false
-	testcase.Ferry.BeforeBatchCopyListener = func(batch *ghostferry.RowBatch) error {
+	testcase.Ferry.BeforeBatchCopyListener = func(batch ghostferry.RowBatch) error {
 		if lastRowDeleted {
 			return nil
 		}

--- a/test/go/row_batch_test.go
+++ b/test/go/row_batch_test.go
@@ -57,7 +57,7 @@ func (this *RowBatchTestSuite) TestRowBatchGeneratesInsertQuery() {
 		ghostferry.RowData{1001, []byte("val2"), true},
 		ghostferry.RowData{1002, []byte("val3"), true},
 	}
-	batch := ghostferry.NewRowBatch(this.sourceTable, vals, 0)
+	batch := ghostferry.NewDataRowBatchWithPaginationKey(this.sourceTable, vals, 0)
 	this.Require().Equal(vals, batch.Values())
 
 	q1, v1, err := batch.AsSQLQuery(this.targetTable.Schema, this.targetTable.Name)
@@ -79,7 +79,7 @@ func (this *RowBatchTestSuite) TestRowBatchWithWrongColumnsReturnsError() {
 		ghostferry.RowData{1001},
 		ghostferry.RowData{1002, []byte("val2"), true},
 	}
-	batch := ghostferry.NewRowBatch(this.sourceTable, vals, 0)
+	batch := ghostferry.NewDataRowBatchWithPaginationKey(this.sourceTable, vals, 0)
 
 	_, _, err := batch.AsSQLQuery(this.targetTable.Schema, this.targetTable.Name)
 	this.Require().NotNil(err)
@@ -90,7 +90,7 @@ func (this *RowBatchTestSuite) TestRowBatchMetadata() {
 	vals := []ghostferry.RowData{
 		ghostferry.RowData{1000},
 	}
-	batch := ghostferry.NewRowBatch(this.sourceTable, vals, 0)
+	batch := ghostferry.NewDataRowBatchWithPaginationKey(this.sourceTable, vals, 0)
 
 	this.Require().Equal("test_schema", batch.TableSchema().Schema)
 	this.Require().Equal("test_table", batch.TableSchema().Name)
@@ -103,7 +103,7 @@ func (this *RowBatchTestSuite) TestRowBatchNoPaginationKeyIndex() {
 	vals := []ghostferry.RowData{
 		ghostferry.RowData{"hello"},
 	}
-	batch := ghostferry.NewRowBatch(this.sourceTable, vals, -1)
+	batch := ghostferry.NewDataRowBatch(this.sourceTable, vals)
 
 	this.Require().Equal(false, batch.ValuesContainPaginationKey())
 }

--- a/test/helpers/ghostferry_helper.rb
+++ b/test/helpers/ghostferry_helper.rb
@@ -123,6 +123,14 @@ module GhostferryHelper
       raise "Ghostferry did not get interrupted"
     end
 
+    def run_expecting_crash(resuming_state = nil)
+      run(resuming_state)
+    rescue GhostferryExitFailure
+      return @stdout.join("\n"), @stderr.join("\n")
+    else
+      raise "Ghostferry did not crash"
+    end
+
     ######################################################
     # Methods representing the different stages of `run` #
     ######################################################

--- a/test/integration/full_table_copy_test.rb
+++ b/test/integration/full_table_copy_test.rb
@@ -1,0 +1,64 @@
+require "test_helper"
+
+class FullTableCopyTest < GhostferryTestCase
+  def test_reject_table_with_string_primary_key
+    define_test_table_with_data("data varchar(32), primary key(data)")
+
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY)
+    _, stderr = ghostferry.run_expecting_crash
+    assert_includes stderr, "panic: Pagination Key `data` for `gftest`.`test_table_1` is non-numeric"
+  end
+
+  def test_reject_table_without_primary_key
+    define_test_table_with_data("data varchar(32)")
+
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY)
+    _, stderr = ghostferry.run_expecting_crash
+    assert_includes stderr, "panic: `gftest`.`test_table_1` has no Primary Key to default to for Pagination purposes"
+  end
+
+  def test_copy_table_with_string_primary_key
+    define_test_table_with_data("data varchar(32), primary key(data)")
+
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY, config: {
+        cascading_pagination_column_config: {
+            FullTableCopies: {
+                DEFAULT_DB => [
+                    DEFAULT_TABLE,
+                ],
+            },
+        }.to_json,
+    })
+    ghostferry.run
+
+    assert_test_table_is_identical
+  end
+
+  def test_copy_table_without_primary_key
+    define_test_table_with_data("data varchar(32)")
+
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY, config: {
+        cascading_pagination_column_config: {
+            FullTableCopies: {
+                DEFAULT_DB => [
+                    DEFAULT_TABLE,
+                ],
+            },
+        }.to_json,
+    })
+    ghostferry.run
+
+    assert_test_table_is_identical
+  end
+
+  private
+
+  def define_test_table_with_data(column_definition)
+    [source_db, target_db].each do |db|
+      db.query("CREATE DATABASE IF NOT EXISTS #{DEFAULT_DB}")
+      db.query("CREATE TABLE IF NOT EXISTS #{DEFAULT_FULL_TABLE_NAME} (#{column_definition})")
+    end
+
+    source_db.query("INSERT INTO #{DEFAULT_FULL_TABLE_NAME} (data) VALUES ('data1'), ('data2')")
+  end
+end

--- a/test/lib/go/integrationferry.go
+++ b/test/lib/go/integrationferry.go
@@ -76,7 +76,7 @@ func (f *IntegrationFerry) SendStatusAndWaitUntilContinue(status string, data ..
 // Method override for Start in order to send status to the integration
 // server.
 func (f *IntegrationFerry) Start() error {
-	f.Ferry.DataIterator.AddBatchListener(func(rowBatch *ghostferry.RowBatch) error {
+	f.Ferry.DataIterator.AddBatchListener(func(rowBatch ghostferry.RowBatch) error {
 		return f.SendStatusAndWaitUntilContinue(StatusBeforeRowCopy, rowBatch.TableSchema().Name)
 	})
 
@@ -89,7 +89,7 @@ func (f *IntegrationFerry) Start() error {
 		return err
 	}
 
-	f.Ferry.DataIterator.AddBatchListener(func(rowBatch *ghostferry.RowBatch) error {
+	f.Ferry.DataIterator.AddBatchListener(func(rowBatch ghostferry.RowBatch) error {
 		return f.SendStatusAndWaitUntilContinue(StatusAfterRowCopy, rowBatch.TableSchema().Name)
 	})
 

--- a/testhelpers/test_ferry.go
+++ b/testhelpers/test_ferry.go
@@ -10,11 +10,11 @@ import (
 type TestFerry struct {
 	*ghostferry.Ferry
 
-	BeforeBatchCopyListener   func(batch *ghostferry.RowBatch) error
+	BeforeBatchCopyListener   func(batch ghostferry.RowBatch) error
 	BeforeBinlogApplyListener func(events []ghostferry.DMLEvent) error
 	BeforeRowCopyDoneListener func() error
 
-	AfterBatchCopyListener   func(batch *ghostferry.RowBatch) error
+	AfterBatchCopyListener   func(batch ghostferry.RowBatch) error
 	AfterBinlogApplyListener func(events []ghostferry.DMLEvent) error
 	AfterRowCopyDoneListener func() error
 }


### PR DESCRIPTION
This commit adds the ability to mark tables as "full-table copy" tables,
for which we copy all table rows using a simple SQL table "offset",
allowing to copy (small) tables that do not have indices we can use to
iterate on.

To guarantee correct copy behavior, the source table is locked for the
entire copy procedure, making this viable only for small tables.

Change-Id: Ie009175d94fe9d2c4fd75b63e91243e2260b909d