### PR TITLE
Configurable read-retries in BinlogStreamer

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Features/fixes added in this fork include
   **strongly recommended** to use this feature with care and only on tables with
   few rows, as the copy process requires locking the entire table on the source
   database.
+- use `DBReadRetries` configuration setting also for retrying reading from the
+  binlog server (instead of using a hardcoded retry limit of 5).
 
 Overview of How it Works
 ------------------------

--- a/binlog_streamer.go
+++ b/binlog_streamer.go
@@ -54,6 +54,7 @@ type BinlogStreamer struct {
 	DBConfig            *DatabaseConfig
 	MyServerId          uint32
 	ErrorHandler        ErrorHandler
+	ReadRetries         int
 	Filter              CopyFilter
 
 	TableSchema         TableSchemaCache
@@ -181,7 +182,7 @@ func (s *BinlogStreamer) Run() {
 		var ev *replication.BinlogEvent
 		var timedOut bool
 
-		err := WithRetries(5, 0, s.logger, "get binlog event", func() (er error) {
+		err := WithRetries(s.ReadRetries, 0, s.logger, "get binlog event", func() (er error) {
 			ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 			defer cancel()
 			ev, er = s.binlogStreamer.GetEvent(ctx)

--- a/ferry.go
+++ b/ferry.go
@@ -127,6 +127,7 @@ func (f *Ferry) NewBinlogStreamer() *BinlogStreamer {
 		DBConfig:     f.Source,
 		MyServerId:   f.Config.MyServerId,
 		ErrorHandler: f.ErrorHandler,
+		ReadRetries:  f.DBReadRetries,
 		Filter:       f.CopyFilter,
 		TableSchema:  f.Tables,
 	}

--- a/test/go/binlog_streamer_test.go
+++ b/test/go/binlog_streamer_test.go
@@ -53,6 +53,7 @@ func (this *BinlogStreamerTestSuite) SetupTest() {
 		DBConfig:     testFerry.Config.Source,
 		MyServerId:   testFerry.Config.MyServerId,
 		ErrorHandler: testFerry.ErrorHandler,
+		ReadRetries:  testFerry.DBReadRetries,
 		Filter:       testFerry.CopyFilter,
 		TableSchema:  tableSchemaCache,
 	}


### PR DESCRIPTION
Start using the "DBReadRetries", which is documented as

  The maximum number of retries for reads if the reads fail on the
  source database.

to also specify the number of retries when reading binlogs from the
source. It seems to be applicable here as well.

Both values internally default to 5, unless otherwise specified, so the
change is backwards-compatible, unless callers specify a different
value.

Change-Id: I53bd420cd1feaee7ba66d4516ac273cd9fdd2ac1