### PR TITLE
Fix handling of uint values #165

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Features/fixes added in this fork include
   database states that are not recoverable.
 - use `DBReadRetries` configuration setting also for retrying reading from the
   binlog server (instead of using a hardcoded retry limit of 5).
+- more robust [handling of bigint column values](https://github.com/Shopify/ghostferry/issues/165):
+  this fix has not made it into upstream master yet.
 
 Overview of How it Works
 ------------------------

--- a/test/go/dml_events_test.go
+++ b/test/go/dml_events_test.go
@@ -244,6 +244,64 @@ func (this *DMLEventsTestSuite) TestBinlogDeleteEventMetadata() {
 	this.Require().Nil(dmlEvents[0].NewValues())
 }
 
+func (this *DMLEventsTestSuite) testPaginationKey(rows [][]interface{}) uint64 {
+	rowsEvent := &replication.RowsEvent{
+		Table: this.tableMapEvent,
+		Rows:  rows,
+	}
+	dmlEvents, _ := ghostferry.NewBinlogInsertEvents(this.sourceTable, rowsEvent, ghostferry.BinlogPosition{})
+
+	pagintionKey, err := dmlEvents[0].PaginationKey()
+	this.Require().Nil(err)
+	return pagintionKey
+}
+
+func (this *DMLEventsTestSuite) TestPaginationKeyForInt() {
+	testValue := 1000
+	paginationKey := this.testPaginationKey([][]interface{}{{testValue, 0, 0}})
+	this.Require().Equal(paginationKey, uint64(testValue))
+}
+
+func (this *DMLEventsTestSuite) TestPaginationKeyForUint64() {
+	testValue := uint64(1000)
+	paginationKey := this.testPaginationKey([][]interface{}{{testValue, 0, 0}})
+	this.Require().Equal(paginationKey, testValue)
+}
+
+func (this *DMLEventsTestSuite) TestPaginationKeyForUint32() {
+	testValue := uint32(1000)
+	paginationKey := this.testPaginationKey([][]interface{}{{testValue, 0, 0}})
+	this.Require().Equal(paginationKey, uint64(testValue))
+}
+
+func (this *DMLEventsTestSuite) TestPaginationKeyForUint16() {
+	testValue := uint16(1000)
+	paginationKey := this.testPaginationKey([][]interface{}{{testValue, 0, 0}})
+	this.Require().Equal(paginationKey, uint64(testValue))
+}
+
+func (this *DMLEventsTestSuite) TestPaginationKeyForUint8() {
+	testValue := uint8(255)
+	paginationKey := this.testPaginationKey([][]interface{}{{testValue, 0, 0}})
+	this.Require().Equal(paginationKey, uint64(testValue))
+}
+
+func (this *DMLEventsTestSuite) TestPaginationKeyForUint() {
+	testValue := uint(1000)
+	paginationKey := this.testPaginationKey([][]interface{}{{testValue, 0, 0}})
+	this.Require().Equal(paginationKey, uint64(testValue))
+}
+
+func (this *DMLEventsTestSuite) TestPaginationKeyForByteArray() {
+	paginationKey := this.testPaginationKey([][]interface{}{{[]byte("1000"), 0, 0}})
+	this.Require().Equal(paginationKey, uint64(1000))
+}
+
+func (this *DMLEventsTestSuite) TestPaginationKeyForString() {
+	paginationKey := this.testPaginationKey([][]interface{}{{"1000", 0, 0}})
+	this.Require().Equal(paginationKey, uint64(1000))
+}
+
 func TestDMLEventsTestSuite(t *testing.T) {
 	suite.Run(t, new(DMLEventsTestSuite))
 }

--- a/test/integration/types_test.rb
+++ b/test/integration/types_test.rb
@@ -268,6 +268,21 @@ class TypesTest < GhostferryTestCase
     end
   end
 
+  def test_uint64
+    # the mysql returns signed integers for bigint columns, requiring special
+    # conversion in ghostferry
+    [source_db, target_db].each do |db|
+      db.query("CREATE DATABASE IF NOT EXISTS #{DEFAULT_DB}")
+      db.query("CREATE TABLE IF NOT EXISTS #{DEFAULT_FULL_TABLE_NAME} (id bigint(19) unsigned NOT NULL AUTO_INCREMENT, primary key(id))")
+    end
+
+    source_db.query("INSERT INTO #{DEFAULT_FULL_TABLE_NAME} (id) VALUES (1), (1000), (10000000000)")
+
+    new_ghostferry(MINIMAL_GHOSTFERRY).run
+
+    assert_test_table_is_identical
+  end
+
   def test_decimal
     # decimals are treated specially in binlog writing (they are inserted after
     # conversion to string), so we add this test to make sure we don't corrupt


### PR DESCRIPTION
This commit fixes the helper methods for converting uint column values.
The MySQL driver returns signed integers for unsigned integer columns,
but our internal code sometimes generates signed values - in these
cases, the helper crashes.

Change-Id: Id1c770981b6cd05290f40708a284c3d3d8bfcae5