### PR TITLE
Allow state tracking via fixed file #163

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Features/fixes added in this fork include
   binlog server (instead of using a hardcoded retry limit of 5).
 - more robust [handling of bigint column values](https://github.com/Shopify/ghostferry/issues/165):
   this fix has not made it into upstream master yet.
+- support [writing resume/state data to file](https://github.com/Shopify/ghostferry/issues/163)
+  instead of using *stdout*.
 
 Overview of How it Works
 ------------------------

--- a/config.go
+++ b/config.go
@@ -401,6 +401,13 @@ type Config struct {
 	// by dumping the current state to stdout and the error HTTP callback.
 	// The dumped state can be used to resume Ghostferry.
 	DumpStateOnSignal bool
+	// When dumping state is enabled, the file to which to write the state. If
+	// this is not set, use stdout.
+	//
+	// NOTE: Writing state to disk (rather than stdout) has the benefit that
+	// ghostferry can control when is a good time to write state and when to
+	// leave a previously existing state file intact
+	StateFilename string
 
 	// Config for the ControlServer
 	ServerBindAddr string

--- a/examples/copydb/state-file-on-disk-conf.json
+++ b/examples/copydb/state-file-on-disk-conf.json
@@ -1,0 +1,35 @@
+{
+  "Source": {
+    "Host": "127.0.0.1",
+    "Port": 29291,
+    "User": "root",
+    "Pass": "",
+    "Collation": "utf8mb4_unicode_ci",
+    "Params": {
+      "charset": "utf8mb4"
+    }
+  },
+
+  "Target": {
+    "Host": "127.0.0.1",
+    "Port": 29292,
+    "User": "root",
+    "Pass": "",
+    "Collation": "utf8mb4_unicode_ci",
+    "Params": {
+      "charset": "utf8mb4"
+    }
+  },
+
+  "Databases": {
+    "Whitelist": ["abc"]
+  },
+
+  "Tables": {
+    "Blacklist": ["schema_migrations"]
+  },
+
+  "DBReadRetries": 3,
+  "DumpStateOnSignal": true,
+  "StateFilename": "./resume-state.json"
+}

--- a/ferry.go
+++ b/ferry.go
@@ -396,9 +396,11 @@ func (f *Ferry) Initialize() (err error) {
 
 	// Initializing the necessary components of Ghostferry.
 	if f.ErrorHandler == nil {
+		f.logger.Debugf("setting up error handler: %s", f.StateFilename)
 		f.ErrorHandler = &PanicErrorHandler{
 			Ferry:             f,
-			DumpStateToStdout: true,
+			DumpState:         true,
+			DumpStateFilename: f.StateFilename,
 		}
 	}
 
@@ -557,11 +559,14 @@ func (f *Ferry) Run() {
 	}
 
 	if f.DumpStateOnSignal {
+		f.logger.Debug("Setting up DumpStateOnSignal")
 		go func() {
 			c := make(chan os.Signal, 1)
 			signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
 
+			f.logger.Debug("Waiting for DumpStateOnSignal")
 			s := <-c
+			f.logger.Info("Received DumpStateOnSignal")
 			if ctx.Err() == nil {
 				// Ghostferry is still running
 				f.ErrorHandler.Fatal("user_interrupt", fmt.Errorf("signal received: %v", s.String()))

--- a/sharding/sharding.go
+++ b/sharding/sharding.go
@@ -63,9 +63,9 @@ func NewFerry(config *Config) (*ShardingFerry, error) {
 	logger := logrus.WithField("tag", "sharding")
 
 	ferry.ErrorHandler = &ghostferry.PanicErrorHandler{
-		Ferry:             ferry,
-		ErrorCallback:     config.ErrorCallback,
-		DumpStateToStdout: false,
+		Ferry:         ferry,
+		ErrorCallback: config.ErrorCallback,
+		DumpState:     false,
 	}
 
 	return &ShardingFerry{

--- a/test/lib/go/integrationferry.go
+++ b/test/lib/go/integrationferry.go
@@ -294,7 +294,7 @@ func main() {
 		ErrorCallback: ghostferry.HTTPCallback{
 			URI: fmt.Sprintf("http://localhost:%s/callbacks/error", integrationPort),
 		},
-		DumpStateToStdout: true,
+		DumpState: true,
 	}
 
 	err = f.Main()


### PR DESCRIPTION
The previous handling of state across runs of ghostferry was only
allowing the use of stdout. In cases where the tools fails to start,
this mean that the output in stdout was not a valid state, and the
caller has to take special precaution to not override the previous
state.

This commit extends the state handling to allow passing a state file in
the configuration. This state is loaded (if not overridden with the
state file provided as command-line argument), and the state is written
to this file only when the tool shuts down in a way that the output will
be a valid state.

Change-Id: If39728a7c3fc3e0182c2f972f771fb698371d0ce