### PR TITLE
Allow storing resume state in DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Features/fixes added in this fork include
   this fix has not made it into upstream master yet.
 - support [writing resume/state data to file](https://github.com/Shopify/ghostferry/issues/163)
   instead of using *stdout*.
+- support [writing resume/state data to target database](https://github.com/Shopify/ghostferry/issues/163).
 
 Overview of How it Works
 ------------------------

--- a/copydb/cmd/main.go
+++ b/copydb/cmd/main.go
@@ -82,7 +82,6 @@ func main() {
 	// if the state file is not provided as command-line argument, check if we
 	// are tracking state in a file according to the config. If so, and the file
 	// exists, read from there
-	runTargetInitialization := true
 	if stateFilePath == "" {
 		// unlike when provided as command-line argument, we don't require the
 		// file to exist - it simply means that we will want to serialize to
@@ -117,7 +116,6 @@ func main() {
 		}
 
 		logger.Debugf("Parsing state file %s successful", stateFilePath)
-		runTargetInitialization = false
 	}
 
 	err = config.InitializeAndValidateConfig()
@@ -142,7 +140,7 @@ func main() {
 		return
 	}
 
-	if runTargetInitialization {
+	if ferry.Ferry.StateToResumeFrom == nil {
 		logger.Debugf("Initializing target database tables")
 		err = ferry.CreateDatabasesAndTables()
 		if err != nil {

--- a/error_handler.go
+++ b/error_handler.go
@@ -51,6 +51,16 @@ func (this *PanicErrorHandler) ReportError(from string, err error) {
 		}
 	}
 
+	if this.Ferry.StateTracker != nil {
+		logger.Debug("storing state to target DB...")
+		dbErr := this.Ferry.StateTracker.SerializeToDB(this.Ferry.TargetDB)
+		if dbErr != nil {
+			logger.WithError(dbErr).Error("failed to store state to target DB...")
+		} else {
+			logger.Info("stored state to target DB")
+		}
+	}
+
 	// Invoke ErrorCallback if defined
 	if this.ErrorCallback != (HTTPCallback{}) {
 		client := &http.Client{}

--- a/examples/copydb/state-in-target-db-conf.json
+++ b/examples/copydb/state-in-target-db-conf.json
@@ -1,0 +1,36 @@
+{
+  "Source": {
+    "Host": "127.0.0.1",
+    "Port": 29291,
+    "User": "root",
+    "Pass": "",
+    "Collation": "utf8mb4_unicode_ci",
+    "Params": {
+      "charset": "utf8mb4"
+    }
+  },
+
+  "Target": {
+    "Host": "127.0.0.1",
+    "Port": 29292,
+    "User": "root",
+    "Pass": "",
+    "Collation": "utf8mb4_unicode_ci",
+    "Params": {
+      "charset": "utf8mb4"
+    }
+  },
+
+  "Databases": {
+    "Whitelist": ["abc"]
+  },
+
+  "Tables": {
+    "Blacklist": ["schema_migrations"]
+  },
+
+  "DBReadRetries": 3,
+  "DumpStateOnSignal": false,
+  "ResumeStateFromTargetDB": "_ghostferry",
+  "ForceResumeStateUpdatesToDB": true
+}

--- a/state_tracker.go
+++ b/state_tracker.go
@@ -2,10 +2,15 @@ package ghostferry
 
 import (
 	"container/ring"
+	"fmt"
+	sqlorig "database/sql"
+	sql "github.com/Shopify/ghostferry/sqlwrapper"
 	"math"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/Masterminds/squirrel"
 	"github.com/sirupsen/logrus"
 )
 
@@ -88,6 +93,9 @@ type StateTracker struct {
 	lastSuccessfulPaginationKeys map[string]uint64
 	completedTables              map[string]bool
 
+	// optional database+table prefix to which we write the current status
+	stateTablesPrefix string
+
 	logger            *logrus.Entry
 	iterationSpeedLog *ring.Ring
 }
@@ -115,6 +123,33 @@ func NewStateTrackerFromSerializedState(speedLogCount int, serializedState *Seri
 	return s
 }
 
+func NewStateTrackerFromTargetDB(f *Ferry) (s *StateTracker, state *SerializableState, err error) {
+	s = NewStateTracker(f.DataIterationConcurrency*10)
+	s.stateTablesPrefix = fmt.Sprintf("%s._ghostferry_%d_", f.Config.ResumeStateFromDB, f.MyServerId)
+
+	state, err = s.readStateFromDB(f)
+	if err == nil && state == nil {
+		err = s.initializeDBStateSchema(f.TargetDB, f.Config.ResumeStateFromDB)
+
+		masterPos, posErr := ShowMasterStatusBinlogPosition(f.SourceDB)
+		if posErr != nil {
+			s.logger.WithError(posErr).Error("failed to read current binlog position")
+			err = posErr
+			return
+		}
+		pos := NewResumableBinlogPosition(masterPos)
+		s.UpdateLastWrittenBinlogPosition(pos)
+		s.UpdateLastStoredBinlogPositionForInlineVerifier(pos)
+		// we absolutely need to initialize the DB with a proper state of the source
+		// DB here, or we may end up never writing the state to the target DB state
+		// tables, meaning that we resume at an invalid position although we already
+		// started copying table rows
+		s.SerializeToDB(f.TargetDB)
+	}
+
+	return
+}
+
 func (s *StateTracker) UpdateLastWrittenBinlogPosition(pos BinlogPosition) {
 	s.BinlogRWMutex.Lock()
 	defer s.BinlogRWMutex.Unlock()
@@ -127,7 +162,7 @@ func (s *StateTracker) UpdateLastStoredBinlogPositionForInlineVerifier(pos Binlo
 	s.BinlogRWMutex.Lock()
 	defer s.BinlogRWMutex.Unlock()
 
-	s.logger.Debugf("updating last stored binlog position for inline verifier: %s", pos)
+	s.logger.Debugf("updating stored binlog position for inline verifier: %s", pos)
 	s.lastStoredBinlogPositionForInlineVerifier = pos
 }
 
@@ -248,4 +283,372 @@ func (s *StateTracker) Serialize(lastKnownTableSchemaCache TableSchemaCache, bin
 	}
 
 	return state
+}
+
+func (s *StateTracker) SerializeToDB(db *sql.DB) error {
+	if s.stateTablesPrefix == "" {
+		return nil
+	}
+
+	s.BinlogRWMutex.RLock()
+	defer s.BinlogRWMutex.RUnlock()
+
+	s.CopyRWMutex.RLock()
+	defer s.CopyRWMutex.RUnlock()
+
+	binlogTableName := s.getBinLogWriterStateTable()
+	s.logger.Debugf("storing state table %s: %v", binlogTableName, s.lastWrittenBinlogPosition)
+	binlogInitSql, binlogInitArgs, err := s.GetStoreBinlogWriterPositionSql(s.lastWrittenBinlogPosition)
+	if err != nil {
+		s.logger.WithField("err", err).Errorf("generating state sql for %s failed", binlogTableName)
+		return err
+	}
+	_, err = db.Exec(binlogInitSql, binlogInitArgs...)
+	if err != nil {
+		s.logger.WithField("err", err).Errorf("storing state table %s failed", binlogTableName)
+		return err
+	}
+
+	inlineVerifierTableName := s.getInlineVerifierStateTable()
+	s.logger.Debugf("storing state table %s: %v", inlineVerifierTableName, s.lastStoredBinlogPositionForInlineVerifier)
+	inlineVerifierInitSql, inlineVerifierInitArgs, err := s.GetStoreInlineVerifierPositionSql(s.lastStoredBinlogPositionForInlineVerifier)
+	if err != nil {
+		s.logger.WithField("err", err).Errorf("generating state sql for %s failed", inlineVerifierTableName)
+		return err
+	}
+	_, err = db.Exec(inlineVerifierInitSql, inlineVerifierInitArgs...)
+	if err != nil {
+		s.logger.WithField("err", err).Errorf("storing state table %s failed", inlineVerifierTableName)
+		return err
+	}
+
+	for tableName, lastPaginationKey := range s.lastSuccessfulPaginationKeys {
+		s.logger.Debugf("storing copy state for %s: %d", tableName, lastPaginationKey)
+
+		paginationSql, paginationArgs, err := s.GetStoreRowCopyPositionSql(tableName, lastPaginationKey)
+		if err != nil {
+			s.logger.WithField("err", err).Errorf("generating copy-state sql for %s failed", tableName)
+			return err
+		}
+		_, err = db.Exec(paginationSql, paginationArgs...)
+		if err != nil {
+			s.logger.WithField("err", err).Errorf("storing copy-state for %s failed", tableName)
+			return err
+		}
+	}
+
+	for tableName, isDone := range s.completedTables {
+		if isDone {
+			s.logger.Debugf("storing copy state done for %s", tableName)
+
+			doneSql, doneArgs, err := s.GetStoreRowCopyDoneSql(tableName)
+			if err != nil {
+				s.logger.WithField("err", err).Errorf("generating copy-state-done sql for %s failed", tableName)
+				return err
+			}
+			_, err = db.Exec(doneSql, doneArgs...)
+			if err != nil {
+				s.logger.WithField("err", err).Errorf("storing copy-state-done for %s failed", tableName)
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (s *StateTracker) getRowCopyStateTable() string {
+	return s.stateTablesPrefix + "_row_copy_state"
+}
+
+func (s *StateTracker) getBinLogWriterStateTable() string {
+	return s.stateTablesPrefix + "_last_binlog_writer_state"
+}
+
+func (s *StateTracker) getInlineVerifierStateTable() string {
+	return s.stateTablesPrefix + "_last_inline_verifier_state"
+}
+
+func (s *StateTracker) initializeDBStateSchema(db *sql.DB, stateDatabase string) error {
+	s.logger.Infof("initializing resume data target database")
+
+	createDatabaseQuery := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", stateDatabase)
+	s.logger.Debugf("creating state database %s on target", stateDatabase)
+	_, err := db.Exec(createDatabaseQuery)
+	if err != nil {
+		s.logger.WithField("err", err).Errorf("creating state database %s on target failed", s.stateTablesPrefix)
+		return err
+	}
+
+	rowCopyTableName := s.getRowCopyStateTable()
+	rowCopyCreateTable := `
+CREATE TABLE ` + rowCopyTableName + ` (
+    table_name varchar(255) CHARACTER SET ascii NOT NULL,
+    last_pagination_key bigint(19) unsigned NOT NULL,
+    copy_complete BOOLEAN NOT NULL DEFAULT FALSE,
+    last_write_timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (table_name)
+)`
+	s.logger.Debugf("creating state table %s on target", rowCopyTableName)
+	_, err = db.Exec(rowCopyCreateTable)
+	if err != nil {
+		s.logger.WithField("err", err).Errorf("creating state table %s on target failed", rowCopyTableName)
+		return err
+	}
+
+	binlogWriterTableName := s.getBinLogWriterStateTable()
+	binlogWriterCreateTable := `
+CREATE TABLE ` + binlogWriterTableName + ` (
+    event_filename varchar(255) CHARACTER SET ascii NOT NULL,
+    event_pos int(11) UNSIGNED NOT NULL,
+    resume_filename varchar(255) CHARACTER SET ascii NOT NULL,
+    resume_pos int(11) UNSIGNED NOT NULL,
+    write_timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+INSERT INTO ` + binlogWriterTableName + ` (event_filename, event_pos, resume_filename, resume_pos)
+    VALUES ('', 0, '', 0)
+`
+	s.logger.Debugf("creating state table %s on target", binlogWriterTableName)
+	_, err = db.Exec(binlogWriterCreateTable)
+	if err != nil {
+		s.logger.WithField("err", err).Errorf("creating state table %s on target failed", binlogWriterTableName)
+		return err
+	}
+
+	// NOTE: The binlog-writer and inline-verifier state tables are very likely
+	// to diverge in state shortly - that's why the code seems a bit repetitive,
+	// but soon won't be so similar any longer
+	inlineVerifierTableName := s.getInlineVerifierStateTable()
+	inlineVerifierCreateTable := `
+CREATE TABLE ` + inlineVerifierTableName + ` (
+    event_filename varchar(255) CHARACTER SET ascii NOT NULL,
+    event_pos int(11) UNSIGNED NOT NULL,
+    resume_filename varchar(255) CHARACTER SET ascii NOT NULL,
+    resume_pos int(11) UNSIGNED NOT NULL,
+    timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+INSERT INTO ` + inlineVerifierTableName + ` (event_filename, event_pos, resume_filename, resume_pos)
+    VALUES ('', 0, '', 0)
+`
+	s.logger.Debugf("creating state table %s on target", inlineVerifierTableName)
+	_, err = db.Exec(inlineVerifierCreateTable)
+	if err != nil {
+		s.logger.WithField("err", err).Errorf("creating state table %s on target failed", inlineVerifierTableName)
+		return err
+	}
+
+	return nil
+}
+
+func (s *StateTracker) readStateFromDB(f *Ferry) (*SerializableState, error) {
+	tokens := strings.Split(s.getRowCopyStateTable(), ".")
+	if len(tokens) != 2 {
+		return nil, fmt.Errorf("invalid target DB state table name %v", tokens)
+	}
+
+	query, args, err := squirrel.
+		Select("1").
+		From("information_schema.tables").
+		Where(squirrel.Eq{"table_schema": tokens[0], "table_name": tokens[1]}).
+		ToSql()
+	if err != nil {
+		s.logger.WithField("err", err).Errorf("reading target DB tables failed")
+		return nil, err
+	}
+
+	var dummy uint64
+	err = f.TargetDB.QueryRow(query, args...).Scan(&dummy)
+	if err == sqlorig.ErrNoRows {
+		return nil, nil
+	}
+
+	s.logger.Infof("reading resume data from target database")
+
+	var tables TableSchemaCache
+	// NOTE: Here we read the state from the *target* DB (rather than the source
+	// DB). This is because the target is in the schema in which we can apply
+	// DML.
+	// If we are still in the copy phase, the schemas must be in sync, because
+	// DDL statements are delayed in the binlog writer until the copy is done.
+	// If we are already in the binlog writing phase, then the target DB is in
+	// sync with the binlog position - that is, any schema differences between
+	// source and target are still in the binlogs yet to be applied.
+	metrics.Measure("LoadTables", nil, 1.0, func() {
+		tables, err = LoadTables(f.TargetDB, f.TableFilter, f.CompressedColumnsForVerification, f.IgnoredColumnsForVerification, f.CascadingPaginationColumnConfig)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	state := &SerializableState{
+		GhostferryVersion:            VersionString,
+		LastKnownTableSchemaCache:    tables,
+		LastSuccessfulPaginationKeys: make(map[string]uint64),
+		CompletedTables:              make(map[string]bool),
+	}
+
+	rowCopyTableName := s.getRowCopyStateTable()
+	s.logger.Debugf("reading state table %s from target", rowCopyTableName)
+	rowCopyRows, err := squirrel.
+		Select("table_name", "last_pagination_key", "copy_complete").
+		From(rowCopyTableName).
+		RunWith(f.TargetDB.DB).
+		Query()
+	if err != nil {
+		s.logger.WithFields(logrus.Fields{
+			"err": err,
+			"table": rowCopyTableName,
+		}).Errorf("reading row-copy resume data from target DB failed")
+		return nil, err
+	}
+	defer rowCopyRows.Close()
+
+	for rowCopyRows.Next() {
+		var tableName string
+		var lastPaginationKey uint64
+		var copyComplete bool
+		err = rowCopyRows.Scan(&tableName, &lastPaginationKey, &copyComplete)
+		if err != nil {
+			s.logger.WithFields(logrus.Fields{
+				"err":   err,
+				"table": rowCopyTableName,
+			}).Errorf("parsing row-copy resume data row from target DB failed")
+			return nil, err
+		}
+
+		state.LastSuccessfulPaginationKeys[tableName] = lastPaginationKey
+		s.UpdateLastSuccessfulPaginationKey(tableName, lastPaginationKey)
+		if copyComplete {
+			s.MarkTableAsCompleted(tableName)
+			state.CompletedTables[tableName] = true
+		}
+	}
+
+	binlogWriterTableName := s.getBinLogWriterStateTable()
+	s.logger.Debugf("reading state table %s from target", binlogWriterTableName)
+	binlogWriterRows, err := squirrel.
+		Select("event_filename", "event_pos", "resume_filename", "resume_pos").
+		From(binlogWriterTableName).
+		Limit(1).
+		RunWith(f.TargetDB.DB).
+		Query()
+	if err != nil {
+		s.logger.WithFields(logrus.Fields{
+			"err": err,
+			"table": binlogWriterTableName,
+		}).Errorf("reading binlog writer resume data from target DB failed")
+		return nil, err
+	}
+	defer binlogWriterRows.Close()
+
+	for binlogWriterRows.Next() {
+		err = binlogWriterRows.Scan(&state.LastWrittenBinlogPosition.EventPosition.Name, &state.LastWrittenBinlogPosition.EventPosition.Pos, &state.LastWrittenBinlogPosition.ResumePosition.Name, &state.LastWrittenBinlogPosition.ResumePosition.Pos)
+		if err != nil {
+			s.logger.WithFields(logrus.Fields{
+				"err":   err,
+				"table": binlogWriterTableName,
+			}).Errorf("parsing binlog writer resume data row from target DB failed")
+			return nil, err
+		}
+		f.logger.Infof("found binlog writer resume position data on target DB: %s", state.LastWrittenBinlogPosition)
+	}
+
+	inlineVerifierTableName := s.getInlineVerifierStateTable()
+	s.logger.Debugf("reading state table %s from target", inlineVerifierTableName)
+	inlineVerifierRows, err := squirrel.
+		Select("event_filename", "event_pos", "resume_filename", "resume_pos").
+		From(inlineVerifierTableName).
+		RunWith(f.TargetDB.DB).
+		Limit(1).
+		Query()
+	if err != nil {
+		s.logger.WithFields(logrus.Fields{
+			"err": err,
+			"table": inlineVerifierTableName,
+		}).Errorf("reading inline-verifier resume data from target DB failed")
+		return nil, err
+	}
+	defer inlineVerifierRows.Close()
+
+	for inlineVerifierRows.Next() {
+		err = inlineVerifierRows.Scan(&state.LastStoredBinlogPositionForInlineVerifier.EventPosition.Name, &state.LastStoredBinlogPositionForInlineVerifier.EventPosition.Pos, &state.LastStoredBinlogPositionForInlineVerifier.ResumePosition.Name, &state.LastStoredBinlogPositionForInlineVerifier.ResumePosition.Pos)
+		if err != nil {
+			s.logger.WithFields(logrus.Fields{
+				"err":   err,
+				"table": inlineVerifierTableName,
+			}).Errorf("parsing inline-verifier resume position data row from target DB failed")
+			return nil, err
+		}
+		f.logger.Infof("found inline-verifier resume position data on target DB: %s", state.LastWrittenBinlogPosition)
+	}
+
+	return state, nil
+}
+
+func (s *StateTracker) GetStoreBinlogWriterPositionSql(pos BinlogPosition) (sqlStr string, args []interface{}, err error) {
+	if s.stateTablesPrefix == "" {
+		return
+	}
+
+	// NOTE: It seems we cannot use a prepared statement here, because the
+	// binlog writer builds a transaction manually. To make sure we don't have
+	// any SQL-injection, we validate the string parameters manually and make
+	// sure to print anything else as INTs
+	if strings.Contains(pos.EventPosition.Name, "'") || strings.Contains(pos.ResumePosition.Name, "'") {
+		err = fmt.Errorf("unexpected/invalid binlog position name: %s", pos)
+		return
+	}
+
+	sqlStr = fmt.Sprintf("UPDATE %s SET event_filename='%s', event_pos=%d, resume_filename='%s', resume_pos=%d", s.getBinLogWriterStateTable(), pos.EventPosition.Name, pos.EventPosition.Pos, pos.ResumePosition.Name, pos.ResumePosition.Pos)
+
+	return
+}
+
+func (s *StateTracker) GetStoreInlineVerifierPositionSql(pos BinlogPosition) (sqlStr string, args []interface{}, err error) {
+	if s.stateTablesPrefix == "" {
+		return
+	}
+
+	// NOTE: It seems we cannot use a prepared statement here, because the
+	// binlog writer builds a transaction manually. To make sure we don't have
+	// any SQL-injection, we validate the string parameters manually and make
+	// sure to print anything else as INTs
+	if strings.Contains(pos.EventPosition.Name, "'") || strings.Contains(pos.ResumePosition.Name, "'") {
+		err = fmt.Errorf("unexpected/invalid inline verifier position name: %s", pos)
+		return
+	}
+
+	sqlStr = fmt.Sprintf("UPDATE %s SET event_filename='%s', event_pos=%d, resume_filename='%s', resume_pos=%d", s.getInlineVerifierStateTable(), pos.EventPosition.Name, pos.EventPosition.Pos, pos.ResumePosition.Name, pos.ResumePosition.Pos)
+
+	return
+}
+
+func (s *StateTracker) GetStoreRowCopyDoneSql(tableName string) (sqlStr string, args []interface{}, err error) {
+	if s.stateTablesPrefix == "" {
+		return
+	}
+
+	sqlStr, args, err = squirrel.
+		Insert(s.getRowCopyStateTable()).
+		Columns("table_name", "last_pagination_key", "copy_complete").
+		Values(tableName, 0, 1).
+		Suffix("ON DUPLICATE KEY UPDATE copy_complete=1").
+		ToSql()
+
+	return
+}
+
+func (s *StateTracker) GetStoreRowCopyPositionSql(tableName string, endPaginationKey uint64) (sqlStr string, args []interface{}, err error) {
+	if s.stateTablesPrefix == "" {
+		return
+	}
+
+	sqlStr, args, err = squirrel.
+		Insert(s.getRowCopyStateTable()).
+		Columns("table_name", "last_pagination_key").
+		Values(tableName, endPaginationKey).
+		Suffix("ON DUPLICATE KEY UPDATE last_pagination_key=?", endPaginationKey).
+		ToSql()
+
+	return
 }

--- a/table_schema_cache.go
+++ b/table_schema_cache.go
@@ -108,6 +108,10 @@ func fullTableName(schemaName, tableName string) string {
 	return fmt.Sprintf("%s.%s", schemaName, tableName)
 }
 
+func QuotedDatabaseNameFromString(database string) string {
+	return fmt.Sprintf("`%s`", database)
+}
+
 func QuotedTableName(table *TableSchema) string {
 	return QuotedTableNameFromString(table.Schema, table.Name)
 }

--- a/test/helpers/db_helper.rb
+++ b/test/helpers/db_helper.rb
@@ -5,8 +5,12 @@ module DbHelper
   ALPHANUMERICS = ("0".."9").to_a + ("a".."z").to_a + ("A".."Z").to_a
   DB_PORTS = {source: 29291, target: 29292}
 
+  DEFAULT_SERVER_ID = 99499
+
   DEFAULT_DB = "gftest"
   DEFAULT_TABLE = "test_table_1"
+
+  DEFAULT_STATE_DB = "_ghostferry"
 
   def self.full_table_name(db, table)
     "`#{db}`.`#{table}`"
@@ -82,6 +86,7 @@ module DbHelper
   def reset_data
     @connections.each do |_, connection|
       connection.query("DROP DATABASE IF EXISTS `#{DEFAULT_DB}`")
+      connection.query("DROP DATABASE IF EXISTS `#{DEFAULT_STATE_DB}`")
     end
   end
 

--- a/test/helpers/ghostferry_helper.rb
+++ b/test/helpers/ghostferry_helper.rb
@@ -36,6 +36,7 @@ module GhostferryHelper
       # This should be in sync with integrationferry.go
       READY = "READY"
       BINLOG_STREAMING_STARTED = "BINLOG_STREAMING_STARTED"
+      BINLOG_STREAMING_STOPPED = "BINLOG_STREAMING_STOPPED"
       ROW_COPY_COMPLETED = "ROW_COPY_COMPLETED"
       VERIFY_DURING_CUTOVER = "VERIFY_DURING_CUTOVER"
       VERIFIED = "VERIFIED"
@@ -233,6 +234,10 @@ module GhostferryHelper
 
         if @config[:cascading_pagination_column_config]
           environment["GHOSTFERRY_CASCADING_PAGINATION_COLUMN_CONFIG"] = @config[:cascading_pagination_column_config]
+        end
+
+        if @config[:resume_state_from_db]
+          environment["GHOSTFERRY_RESUMESTATEFROMDB"] = @config[:resume_state_from_db]
         end
 
         @logger.info("starting ghostferry test binary #{@compiled_binary_path}")


### PR DESCRIPTION
This commit introduces the ability to store the state to resume from in
a dedicated database, accessed via the "target DB" handle. This is
useful when the client should not store any state, or when we need to
guarantee that a write to the target DB also updates the state in the
same transaction (avoiding double-applying copy/binlog operations).

Change-Id: Id88bc7dad322676e930306a0153d7339ae5aaf12