### PR TITLE
Support copying tables without "paging" keys #162 (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Talk to us on IRC at [irc.freenode.net #ghostferry](https://webchat.freenode.net
 Stable Versus Experimental
 --------------------------
 
-This project is an *experimental *fork of the official
+This project is an *experimental* fork of the official
 [ghostferry project](https://github.com/Shopify/ghostferry). We add various
 features and fixes that have not (yet) made it into the upstream version.
 
@@ -66,6 +66,13 @@ Features/fixes added in this fork include
 - support [writing resume/state data to file](https://github.com/Shopify/ghostferry/issues/163)
   instead of using *stdout*.
 - support [writing resume/state data to target database](https://github.com/Shopify/ghostferry/issues/163).
+- support [copying tables without "paging" primary keys](https://github.com/Shopify/ghostferry/issues/162):
+  `Ghostferry` requires integer auto-increment primary keys for copying data.
+  An optional feature in this fork allows marking tables for "full copy",
+  allowing to copy tables that do not meet this primary key requirement. It is
+  **strongly recommended** to use this feature with care and only on tables with
+  few rows, as the copy process requires locking the entire table on the source
+  database.
 
 Overview of How it Works
 ------------------------

--- a/batch_writer.go
+++ b/batch_writer.go
@@ -35,23 +35,8 @@ func (w *BatchWriter) Initialize() {
 	w.logger = logrus.WithField("tag", "batch_writer")
 }
 
-func (w *BatchWriter) WriteRowBatch(batch *RowBatch) error {
-	return WithRetries(w.WriteRetries, 0, w.logger, "write batch to target", func() error {
-		values := batch.Values()
-		if len(values) == 0 {
-			return nil
-		}
-
-		startPaginationKeypos, err := values[0].GetUint64(batch.PaginationKeyIndex())
-		if err != nil {
-			return err
-		}
-
-		endPaginationKeypos, err := values[len(values)-1].GetUint64(batch.PaginationKeyIndex())
-		if err != nil {
-			return err
-		}
-
+func (w *BatchWriter) WriteRowBatch(batch RowBatch) error {
+	return WithRetries(w.WriteRetries, 0, w.logger, "write batch to target", func() (err error) {
 		db := batch.TableSchema().Schema
 		if targetDbName, exists := w.DatabaseRewrites[db]; exists {
 			db = targetDbName
@@ -62,52 +47,176 @@ func (w *BatchWriter) WriteRowBatch(batch *RowBatch) error {
 			table = targetTableName
 		}
 
-		query, args, err := batch.AsSQLQuery(db, table)
-		if err != nil {
-			return fmt.Errorf("during generating sql query at paginationKey %v -> %v: %v", startPaginationKeypos, endPaginationKeypos, err)
+		if batch.Size() == 0 {
+			w.logger.Debug("ignoring empty row-batch for %s.%s", db, table)
+			return
 		}
 
-		stmt, err := w.stmtCache.StmtFor(w.DB, query)
-		if err != nil {
-			return fmt.Errorf("during prepare query near paginationKey %v -> %v (%s): %v", startPaginationKeypos, endPaginationKeypos, query, err)
+		txInUse := false
+		tx, dbErr := w.DB.Begin()
+		if dbErr != nil {
+			err = fmt.Errorf("unable to begin transaction in BatchWriter: %v", dbErr)
+			return
 		}
 
-		tx, err := w.DB.Begin()
-		if err != nil {
-			return fmt.Errorf("unable to begin transaction in BatchWriter: %v", err)
-		}
-
-		_, err = tx.Stmt(stmt).Exec(args...)
-		if err != nil {
-			tx.Rollback()
-			return fmt.Errorf("during exec query near paginationKey %v -> %v (%s): %v", startPaginationKeypos, endPaginationKeypos, query, err)
-		}
-
-		if w.InlineVerifier != nil {
-			mismatches, err := w.InlineVerifier.CheckFingerprintInline(tx, db, table, batch)
-			if err != nil {
+		// make sure the transaction gets abandoned if we didn't commit it
+		defer func() {
+			if tx != nil {
+				w.logger.Debugf("rolling back transaction: %s", err)
 				tx.Rollback()
-				return fmt.Errorf("during fingerprint checking for paginationKey %v -> %v (%s): %v", startPaginationKeypos, endPaginationKeypos, query, err)
 			}
+		}()
 
-			if len(mismatches) > 0 {
-				tx.Rollback()
-				return BatchWriterVerificationFailed{mismatches, batch.TableSchema().String()}
-			}
+		query, args, dbErr := batch.AsSQLQuery(db, table)
+		if dbErr != nil {
+			err = fmt.Errorf("during generating sql batch query: %v", dbErr)
+			return
 		}
 
-		err = tx.Commit()
-		if err != nil {
-			tx.Rollback()
-			return fmt.Errorf("during commit near paginationKey %v -> %v (%s): %v", startPaginationKeypos, endPaginationKeypos, query, err)
+		txUpdated, dbErr := w.queueStatement(tx, query, args)
+		if dbErr != nil {
+			err = dbErr
+			return
+		}
+		if txUpdated {
+			txInUse = true
 		}
 
 		// Note that the state tracker expects us the track based on the original
 		// database and table names as opposed to the target ones.
-		if w.StateTracker != nil {
-			w.StateTracker.UpdateLastSuccessfulPaginationKey(batch.TableSchema().String(), endPaginationKeypos)
+		stateTableName := batch.TableSchema().String()
+
+		switch b := batch.(type) {
+		case InsertRowBatch:
+			endPaginationKeypos, txUpdated, insertErr := w.handleInsertRowBatch(tx, b, db, table)
+			if insertErr != nil {
+				err = insertErr
+				return
+			}
+			if txUpdated {
+				txInUse = true
+			}
+
+			if w.StateTracker != nil {
+				defer func() {
+					if err == nil {
+						w.StateTracker.UpdateLastSuccessfulPaginationKey(stateTableName, endPaginationKeypos)
+					}
+				}()
+			}
 		}
 
-		return nil
+		if batch.IsTableComplete() && w.StateTracker != nil {
+			query, args, stateErr := w.StateTracker.GetStoreRowCopyDoneSql(stateTableName)
+			if stateErr != nil {
+				err = fmt.Errorf("during generating row-copy done: %v", stateErr)
+				return
+			}
+
+			txUpdated, dbErr := w.queueStatement(tx, query, args)
+			if dbErr != nil {
+				err = dbErr
+				return
+			}
+			if txUpdated {
+				txInUse = true
+			}
+
+			defer func() {
+				if err == nil {
+					w.StateTracker.MarkTableAsCompleted(stateTableName)
+				}
+			}()
+		}
+
+		if txInUse {
+			err = tx.Commit()
+			if err != nil {
+				err = fmt.Errorf("during row-copy commit (%s): %v", query, err)
+			} else {
+				// avoid rolling it back (too late anyways) on function exit
+				tx = nil
+			}
+		} else {
+			// we never really added any statement to the transaction - no need
+			// to commit it. This should practically never happen, but let's be
+			// on the safe side
+			w.logger.Debug("discarding empty transaction")
+		}
+
+		return
 	})
+}
+
+func (w *BatchWriter) handleInsertRowBatch(tx *sql.Tx, batch InsertRowBatch, db, table string) (endPaginationKeypos uint64, txUpdated bool, err error) {
+	if !batch.ValuesContainPaginationKey() {
+		return
+	}
+
+	values := batch.Values()
+	index := batch.PaginationKeyIndex()
+	startPaginationKeypos, err := values[0].GetUint64(index)
+	if err != nil {
+		return
+	}
+
+	endPaginationKeypos, err = values[len(values)-1].GetUint64(index)
+	if err != nil {
+		return
+	}
+
+	if w.InlineVerifier != nil {
+		mismatches, verfierErr := w.InlineVerifier.CheckFingerprintInline(tx, db, table, batch)
+		if err != nil {
+			err = fmt.Errorf("during fingerprint checking for paginationKey %v -> %v: %v", startPaginationKeypos, endPaginationKeypos, verfierErr)
+			return
+		}
+		if mismatches != nil && len(mismatches) > 0 {
+			err = BatchWriterVerificationFailed{mismatches, batch.TableSchema().String()}
+			return
+		}
+	}
+
+	if w.StateTracker != nil {
+		// Note that the state tracker expects us the track based on the original
+		// database and table names as opposed to the target ones.
+		query, args, stateErr := w.StateTracker.GetStoreRowCopyPositionSql(batch.TableSchema().String(), endPaginationKeypos)
+		if stateErr != nil {
+			err = fmt.Errorf("during generating row-copy position for paginationKey %v -> %v: %v", startPaginationKeypos, endPaginationKeypos, stateErr)
+			return
+		}
+
+		txUpdatedForState, stateErr := w.queueStatement(tx, query, args)
+		if stateErr != nil {
+			err = fmt.Errorf("during generating row-copy position for paginationKey %v -> %v: %v", startPaginationKeypos, endPaginationKeypos, stateErr)
+			return
+		}
+		if txUpdatedForState {
+			txUpdated = true
+		}
+	}
+
+	return
+}
+
+
+func (w *BatchWriter) queueStatement(tx *sql.Tx, query string, args []interface{}) (txUpdated bool, err error) {
+	if query == "" {
+		return
+	}
+
+	stmt, stmtErr := w.stmtCache.StmtFor(w.DB, query)
+	if stmtErr != nil {
+		err = stmtErr
+		return
+	}
+
+	_, err = tx.Stmt(stmt).Exec(args...)
+	if err != nil {
+		err = fmt.Errorf("during copy statement: %v", err)
+		return
+	}
+
+	txUpdated = true
+	return
 }

--- a/batch_writer.go
+++ b/batch_writer.go
@@ -180,6 +180,11 @@ func (w *BatchWriter) handleInsertRowBatch(tx *sql.Tx, batch InsertRowBatch, db,
 	if w.StateTracker != nil {
 		// Note that the state tracker expects us the track based on the original
 		// database and table names as opposed to the target ones.
+		//
+		// NOTE: We would update the state within a transaction, but we cannot
+		// do that in case of transaction failures. Since it's safe to copy rows
+		// multiple times, it's vital that we commit the transaction before
+		// updating the state tracker
 		query, args, stateErr := w.StateTracker.GetStoreRowCopyPositionSql(batch.TableSchema().String(), endPaginationKeypos)
 		if stateErr != nil {
 			err = fmt.Errorf("during generating row-copy position for paginationKey %v -> %v: %v", startPaginationKeypos, endPaginationKeypos, stateErr)

--- a/config.go
+++ b/config.go
@@ -274,11 +274,32 @@ func (c ColumnIgnoreConfig) IgnoredColumnsFor(schemaName, tableName string) map[
 // precedence.
 type CascadingPaginationColumnConfig struct {
 	// PerTable has greatest specificity and takes precedence over the other options
+	FullTableCopies map[string][]string // SchemaName => TableNames
+
+	// PerTable has next greatest specificity and takes precedence over the other options
 	PerTable map[string]map[string]string // SchemaName => TableName => ColumnName
 
 	// FallbackColumn is a global default to fallback to and is less specific than the
 	// default, which is the Primary Key
 	FallbackColumn string
+}
+
+func (c *CascadingPaginationColumnConfig) IsFullCopyTable(schemaName, tableName string) bool {
+	if c == nil {
+		return false
+	}
+
+	tableConfig, found := c.FullTableCopies[schemaName]
+	if !found {
+		return false
+	}
+
+	for _, table := range tableConfig {
+		if table == tableName {
+			return true
+		}
+	}
+	return false
 }
 
 // PaginationColumnFor is a helper function to retrieve the column name to paginate by
@@ -500,9 +521,10 @@ type Config struct {
 	IgnoredColumnsForVerification ColumnIgnoreConfig
 
 	// Ghostferry requires a single numeric column to paginate over tables. Inferring that column is done in the following exact order:
-	// 1. Use the PerTable pagination column, if configured for a table. Fail if we cannot find this column in the table.
-	// 2. Use the table's primary key column as the pagination column. Fail if the primary key is not numeric or is a composite key without a FallbackColumn specified.
-	// 3. Use the FallbackColumn pagination column, if configured. Fail if we cannot find this column in the table.
+	// 1. Find the table in the FullCopyTables list and perform non-paginated copies (only reasonable for small tables).
+	// 2. Use the PerTable pagination column, if configured for a table. Fail if we cannot find this column in the table.
+	// 3. Use the table's primary key column as the pagination column. Fail if the primary key is not numeric or is a composite key without a FallbackColumn specified.
+	// 4. Use the FallbackColumn pagination column, if configured. Fail if we cannot find this column in the table.
 	CascadingPaginationColumnConfig *CascadingPaginationColumnConfig
 }
 

--- a/cursor.go
+++ b/cursor.go
@@ -41,9 +41,9 @@ type CursorConfig struct {
 	ReadRetries     int
 }
 
-// returns a new Cursor with an embedded copy of itself
-func (c *CursorConfig) NewCursor(table *TableSchema, startPaginationKey, maxPaginationKey uint64) *Cursor {
-	return &Cursor{
+// returns a new PaginatedCursor with an embedded copy of itself
+func (c *CursorConfig) NewPaginatedCursor(table *TableSchema, startPaginationKey, maxPaginationKey uint64) *PaginatedCursor {
+	return &PaginatedCursor{
 		CursorConfig:                *c,
 		Table:                       table,
 		MaxPaginationKey:            maxPaginationKey,
@@ -52,14 +52,14 @@ func (c *CursorConfig) NewCursor(table *TableSchema, startPaginationKey, maxPagi
 	}
 }
 
-// returns a new Cursor with an embedded copy of itself
-func (c *CursorConfig) NewCursorWithoutRowLock(table *TableSchema, startPaginationKey, maxPaginationKey uint64) *Cursor {
-	cursor := c.NewCursor(table, startPaginationKey, maxPaginationKey)
+// returns a new PaginatedCursor with an embedded copy of itself
+func (c *CursorConfig) NewPaginatedCursorWithoutRowLock(table *TableSchema, startPaginationKey, maxPaginationKey uint64) *PaginatedCursor {
+	cursor := c.NewPaginatedCursor(table, startPaginationKey, maxPaginationKey)
 	cursor.RowLock = false
 	return cursor
 }
 
-type Cursor struct {
+type PaginatedCursor struct {
 	CursorConfig
 
 	Table            *TableSchema
@@ -71,7 +71,7 @@ type Cursor struct {
 	logger                      *logrus.Entry
 }
 
-func (c *Cursor) Each(f func(*RowBatch) error) error {
+func (c *PaginatedCursor) Each(f func(RowBatch) error) error {
 	c.logger = logrus.WithFields(logrus.Fields{
 		"table": c.Table.String(),
 		"tag":   "cursor",
@@ -84,7 +84,7 @@ func (c *Cursor) Each(f func(*RowBatch) error) error {
 
 	for c.lastSuccessfulPaginationKey < c.MaxPaginationKey {
 		var tx SqlPreparerAndRollbacker
-		var batch *RowBatch
+		var batch InsertRowBatch
 		var paginationKeypos uint64
 
 		err := WithRetries(c.ReadRetries, 0, c.logger, "fetch rows", func() (err error) {
@@ -142,10 +142,21 @@ func (c *Cursor) Each(f func(*RowBatch) error) error {
 		c.lastSuccessfulPaginationKey = paginationKeypos
 	}
 
+	// notify all listeners that the copy is done. We use a dedicated event for
+	// this to allow listeners an optimized way to look just for this, but also
+	// to avoid corner-cases where tables are empty to begin with or if we end
+	// pagination exactly at a batch-boundary
+	finalizeBatch := NewFinalizeTableCopyBatch(c.Table)
+	err := f(finalizeBatch)
+	if err != nil {
+		c.logger.WithError(err).Error("failed to call finish-each callback")
+		return err
+	}
+
 	return nil
 }
 
-func (c *Cursor) Fetch(db SqlPreparer) (batch *RowBatch, paginationKeypos uint64, err error) {
+func (c *PaginatedCursor) Fetch(db SqlPreparer) (batch InsertRowBatch, paginationKeypos uint64, err error) {
 	var selectBuilder squirrel.SelectBuilder
 
 	if c.BuildSelect != nil {
@@ -245,13 +256,176 @@ func (c *Cursor) Fetch(db SqlPreparer) (batch *RowBatch, paginationKeypos uint64
 		}
 	}
 
-	batch = &RowBatch{
-		values:             batchData,
-		paginationKeyIndex: paginationKeyIndex,
-		table:              c.Table,
+	batch = NewDataRowBatchWithPaginationKey(c.Table, batchData, paginationKeyIndex)
+	logger.Debugf("found %d/%d rows", batch.Size(), c.BatchSize)
+
+	return
+}
+
+// returns a new PaginatedCursor with an embedded copy of itself
+func (c *CursorConfig) NewFullTableCursor(table *TableSchema) *FullTableCursor {
+	return &FullTableCursor{
+		DB:          c.DB,
+		Table:       table,
+		BatchSize:   c.BatchSize,
+		ReadRetries: c.ReadRetries,
+	}
+}
+
+type FullTableCursor struct {
+	DB          *sql.DB
+	Table       *TableSchema
+	BatchSize   uint64
+	ReadRetries int
+
+	logger *logrus.Entry
+}
+
+func (c *FullTableCursor) Each(f func(RowBatch) error) error {
+	c.logger = logrus.WithFields(logrus.Fields{
+		"table": c.Table.String(),
+		"tag":   "fullTableCursor",
+	})
+
+	// we do not support pagination, so we cannot resume copying of full-table
+	// copies. We need to send out a way to re-initialize and prepare for a
+	// full-table copy
+	initBatch := NewTruncateTableBatch(c.Table)
+	err := f(initBatch)
+	if err != nil {
+		c.logger.WithError(err).Error("failed to call init-each callback")
+		return err
 	}
 
-	logger.Debugf("found %d rows", batch.Size())
+	err = WithRetries(c.ReadRetries, 0, c.logger, "fetch rows", func() (err error) {
+		tx, err := c.DB.Begin()
+		if err != nil {
+			return err
+		}
+		defer func() {
+			_, err := tx.Query("UNLOCK TABLES")
+			if err != nil {
+				c.logger.WithError(err).Error("unlocking table failed")
+			}
+			tx.Rollback()
+		}()
+
+		// NOTE: We need to hold the row-lock on all rows for the entire
+		// operation. Yes, crazy, but if we can't paginate, what are we supposed
+		// to do? We really, *really*, *really* only use this for small tables
+		_, err = tx.Query(fmt.Sprintf("LOCK TABLES %s WRITE", QuotedTableName(c.Table)))
+		if err != nil {
+			c.logger.WithError(err).Error("locking table failed")
+			return err
+		}
+
+		rowOffset := 0
+		for {
+			c.logger.Debugf("fetching full-table batch at offset %d", rowOffset)
+			batch, err := c.Fetch(tx, rowOffset)
+			if err != nil {
+				c.logger.WithError(err).Errorf("failed to invoke fetch at offset %d", rowOffset)
+				return err
+			}
+
+			// NOTE: We propagate even an empty batch here to propagate the
+			// fact that the copy is done (e.g., if the table was empty)
+			err = f(batch)
+			if err != nil {
+				c.logger.WithError(err).Error("failed to call each callback")
+				return err
+			}
+
+			if batch.Size() < int(c.BatchSize) {
+				c.logger.Debugf("there are no more rows to copy: last batch contained %d/%d rows", batch.Size(), c.BatchSize)
+				break
+			}
+
+			rowOffset += batch.Size()
+		}
+
+		// notify all listeners that the copy is done. We use a dedicated event for
+		// this to allow listeners an optimized way to look just for this, but also
+		// to avoid corner-cases where tables are empty to begin with or if we end
+		// pagination exactly at a batch-boundary
+		finalizeBatch := NewFinalizeTableCopyBatch(c.Table)
+		err = f(finalizeBatch)
+		if err != nil {
+			c.logger.WithError(err).Error("failed to call finish-each callback")
+			return err
+		}
+
+		return nil
+	})
+
+	return err
+}
+
+func (c *FullTableCursor) Fetch(db SqlPreparer, rowOffset int) (batch InsertRowBatch, err error) {
+	// NOTE: The caller already locked the table for us
+	selectBuilder := squirrel.Select("*").
+		From(QuotedTableName(c.Table)).
+		Limit(c.BatchSize).
+		Offset(uint64(rowOffset))
+	query, args, err := selectBuilder.ToSql()
+	if err != nil {
+		c.logger.WithError(err).Error("failed to build limit-offset sql")
+		return
+	}
+
+	splitQuery := strings.Split(query, "FROM")
+	loggedQuery := fmt.Sprintf("SELECT [omitted] FROM %s", splitQuery[1])
+
+	logger := c.logger.WithFields(logrus.Fields{
+		"sql":  loggedQuery,
+		"args": args,
+	})
+
+	// This query must be a prepared query. If it is not, querying will use
+	// MySQL's plain text interface, which will scan all values into []uint8
+	// if we give it []interface{}.
+	stmt, err := db.Prepare(query)
+	if err != nil {
+		logger.WithError(err).Error("failed to prepare query")
+		return
+	}
+
+	defer stmt.Close()
+
+	rows, err := stmt.Query(args...)
+	if err != nil {
+		logger.WithError(err).Error("failed to query database")
+		return
+	}
+
+	defer rows.Close()
+
+	columns, err := rows.Columns()
+	if err != nil {
+		logger.WithError(err).Error("failed to get columns")
+		return
+	}
+
+	var rowData RowData
+	var batchData []RowData
+
+	for rows.Next() {
+		rowData, err = ScanGenericRow(rows, len(columns))
+		if err != nil {
+			logger.WithError(err).Error("failed to scan row")
+			return
+		}
+
+		batchData = append(batchData, rowData)
+	}
+
+	err = rows.Err()
+	if err != nil {
+		return
+	}
+
+	batch = NewDataRowBatch(c.Table, batchData)
+	logger.Debugf("found %d/%d rows", batch.Size(), c.BatchSize)
 
 	return
 }

--- a/data_iterator.go
+++ b/data_iterator.go
@@ -99,7 +99,9 @@ func (d *DataIterator) Run(tables []*TableSchema) {
 
 	// NOTE: We don't run full-table copies in parallel. These are meant for
 	// small-ish tables and should be kept short (due to full-table locking
-	// on the source)
+	// on the source). For the same reason, we also don't "steal" one of the
+	// limited goroutines controlled by d.Concurrency - we assume the below
+	// goroutine completes fast whereas the above one could take a long time.
 	go func() {
 		defer wg.Done()
 

--- a/data_iterator.go
+++ b/data_iterator.go
@@ -19,7 +19,7 @@ type DataIterator struct {
 	StateTracker *StateTracker
 
 	targetPaginationKeys *sync.Map
-	batchListeners       []func(*RowBatch) error
+	batchListeners       []func(RowBatch) error
 	doneListeners        []func() error
 	logger               *logrus.Entry
 }
@@ -36,108 +36,54 @@ func (d *DataIterator) Run(tables []*TableSchema) {
 	}
 
 	d.logger.WithField("tablesCount", len(tables)).Info("starting data iterator run")
-	tablesWithData, emptyTables, err := MaxPaginationKeys(d.DB, tables, d.logger)
+	paginatedTables, unpaginatedTables, err := MaxPaginationKeys(d.DB, tables, d.logger)
 	if err != nil {
 		d.ErrorHandler.Fatal("data_iterator", err)
 	}
 
-	for _, table := range emptyTables {
-		d.StateTracker.MarkTableAsCompleted(table.String())
-	}
-
-	for table, maxPaginationKey := range tablesWithData {
+	tmp := unpaginatedTables[:0]
+	for _, table := range unpaginatedTables {
 		tableName := table.String()
 		if d.StateTracker.IsTableComplete(tableName) {
 			// In a previous run, the table may have been completed.
 			// We don't need to reiterate those tables as it has already been done.
-			delete(tablesWithData, table)
+			d.logger.WithField("table", tableName).Debug("table already copied completely, removing from unpaginagted table copy list")
+		} else {
+			tmp = append(tmp, table)
+		}
+	}
+	unpaginatedTables = tmp
+
+	for table, maxPaginationKey := range paginatedTables {
+		tableName := table.String()
+		if d.StateTracker.IsTableComplete(tableName) {
+			// In a previous run, the table may have been completed.
+			// We don't need to reiterate those tables as it has already been done.
+			d.logger.WithField("table", tableName).Debug("table already copied completely, removing from paginagted table copy list")
+			delete(paginatedTables, table)
 		} else {
 			d.targetPaginationKeys.Store(table.String(), maxPaginationKey)
 		}
 	}
 
-	tablesQueue := make(chan *TableSchema)
+	paginatedTablesQueue := make(chan *TableSchema)
+	unpaginatedTablesQueue := make(chan *TableSchema)
 	wg := &sync.WaitGroup{}
-	wg.Add(d.Concurrency)
+	wg.Add(d.Concurrency + 1)
 
 	for i := 0; i < d.Concurrency; i++ {
 		go func() {
 			defer wg.Done()
 
 			for {
-				table, ok := <-tablesQueue
+				table, ok := <-paginatedTablesQueue
 				if !ok {
 					break
 				}
 
-				logger := d.logger.WithField("table", table.String())
-
-				targetPaginationKeyInterface, found := d.targetPaginationKeys.Load(table.String())
-				if !found {
-					err := fmt.Errorf("%s not found in targetPaginationKeys, this is likely a programmer error", table.String())
-					logger.WithError(err).Error("this is definitely a bug")
-					d.ErrorHandler.Fatal("data_iterator", err)
-					return
-				}
-
-				startPaginationKey := d.StateTracker.LastSuccessfulPaginationKey(table.String())
-				if startPaginationKey == math.MaxUint64 {
-					err := fmt.Errorf("%v has been marked as completed but a table iterator has been spawned, this is likely a programmer error which resulted in the inconsistent starting state", table.String())
-					logger.WithError(err).Error("this is definitely a bug")
-					d.ErrorHandler.Fatal("data_iterator", err)
-					return
-				}
-
-				cursor := d.CursorConfig.NewCursor(table, startPaginationKey, targetPaginationKeyInterface.(uint64))
-				if d.SelectFingerprint {
-					if len(cursor.ColumnsToSelect) == 0 {
-						cursor.ColumnsToSelect = []string{"*"}
-					}
-
-					cursor.ColumnsToSelect = append(cursor.ColumnsToSelect, table.RowMd5Query())
-				}
-
-				err := cursor.Each(func(batch *RowBatch) error {
-					metrics.Count("RowEvent", int64(batch.Size()), []MetricTag{
-						MetricTag{"table", table.Name},
-						MetricTag{"source", "table"},
-					}, 1.0)
-
-					if d.SelectFingerprint {
-						fingerprints := make(map[uint64][]byte)
-						rows := make([]RowData, batch.Size())
-
-						for i, rowData := range batch.Values() {
-							paginationKey, err := rowData.GetUint64(batch.PaginationKeyIndex())
-							if err != nil {
-								logger.WithError(err).Error("failed to get paginationKey data")
-								return err
-							}
-
-							fingerprints[paginationKey] = rowData[len(rowData)-1].([]byte)
-							rows[i] = rowData[:len(rowData)-1]
-						}
-
-						batch = &RowBatch{
-							values:             rows,
-							paginationKeyIndex: batch.PaginationKeyIndex(),
-							table:              table,
-							fingerprints:       fingerprints,
-						}
-					}
-
-					for _, listener := range d.batchListeners {
-						err := listener(batch)
-						if err != nil {
-							logger.WithError(err).Error("failed to process row batch with listeners")
-							return err
-						}
-					}
-
-					return nil
-				})
-
+				err = d.processPaginatedTable(table)
 				if err != nil {
+					logger := d.logger.WithField("table", table.String())
 					switch e := err.(type) {
 					case BatchWriterVerificationFailed:
 						logger.WithField("incorrect_tables", e.table).Error(e.Error())
@@ -146,43 +92,173 @@ func (d *DataIterator) Run(tables []*TableSchema) {
 						logger.WithError(err).Error("failed to iterate table")
 						d.ErrorHandler.Fatal("data_iterator", err)
 					}
-
 				}
-
-				logger.Debug("table iteration completed")
-
-				// Right now the BatchWriter.WriteRowBatch happens synchronously in
-				// this method. If it ever becomes async, this MarkTableAsCompleted
-				// call MUST be done in WriteRowBatch somehow.
-				d.StateTracker.MarkTableAsCompleted(table.String())
 			}
 		}()
 	}
 
+	// NOTE: We don't run full-table copies in parallel. These are meant for
+	// small-ish tables and should be kept short (due to full-table locking
+	// on the source)
+	go func() {
+		defer wg.Done()
+
+		for {
+			table, ok := <-unpaginatedTablesQueue
+			if !ok {
+				break
+			}
+
+			err := d.processUnpaginatedTable(table)
+			if err != nil {
+				d.ErrorHandler.Fatal("data_iterator", err)
+			}
+		}
+	}()
+
 	i := 0
-	loggingIncrement := len(tablesWithData) / 50
+	totalTablesToCopy := len(paginatedTables) + len(unpaginatedTables)
+	loggingIncrement := totalTablesToCopy / 50
 	if loggingIncrement == 0 {
 		loggingIncrement = 1
 	}
 
-	for table, _ := range tablesWithData {
-		tablesQueue <- table
+	for table, _ := range paginatedTables {
+		paginatedTablesQueue <- table
 		i++
 		if i%loggingIncrement == 0 {
-			d.logger.WithField("table", table.String()).Infof("queued table for processing (%d/%d)", i, len(tablesWithData))
+			d.logger.WithField("table", table.String()).Infof("queued table for paginated processing (%d/%d)", i, totalTablesToCopy)
+		}
+	}
+
+	for _, table := range unpaginatedTables {
+		unpaginatedTablesQueue <- table
+		i++
+		if i%loggingIncrement == 0 {
+			d.logger.WithField("table", table.String()).Infof("queued table for full-table processing (%d/%d)", i, totalTablesToCopy)
 		}
 	}
 
 	d.logger.Info("done queueing tables to be iterated, closing table channel")
-	close(tablesQueue)
+	close(paginatedTablesQueue)
+	close(unpaginatedTablesQueue)
 
+	d.logger.Debug("waiting for table copy to complete")
 	wg.Wait()
+	d.logger.Debug("table copy completed, notifying listeners")
 	for _, listener := range d.doneListeners {
 		listener()
 	}
+	d.logger.Debug("table copy done")
 }
 
-func (d *DataIterator) AddBatchListener(listener func(*RowBatch) error) {
+func (d *DataIterator) processPaginatedTable(table *TableSchema) error {
+	logger := d.logger.WithField("table", table.String())
+
+	targetPaginationKeyInterface, found := d.targetPaginationKeys.Load(table.String())
+	if !found {
+		err := fmt.Errorf("%s not found in targetPaginationKeys, this is likely a programmer error", table.String())
+		logger.WithError(err).Error("this is definitely a bug")
+		return err
+	}
+
+	startPaginationKey := d.StateTracker.LastSuccessfulPaginationKey(table.String())
+	if startPaginationKey == math.MaxUint64 {
+		err := fmt.Errorf("%v has been marked as completed but a table iterator has been spawned, this is likely a programmer error which resulted in the inconsistent starting state", table.String())
+		logger.WithError(err).Error("this is definitely a bug")
+		return err
+	}
+
+	cursor := d.CursorConfig.NewPaginatedCursor(table, startPaginationKey, targetPaginationKeyInterface.(uint64))
+	if d.SelectFingerprint {
+		if len(cursor.ColumnsToSelect) == 0 {
+			cursor.ColumnsToSelect = []string{"*"}
+		}
+
+		cursor.ColumnsToSelect = append(cursor.ColumnsToSelect, table.RowMd5Query())
+	}
+
+	err := cursor.Each(func(batch RowBatch) error {
+		metrics.Count("RowEvent", int64(batch.Size()), []MetricTag{
+			MetricTag{"table", table.Name},
+			MetricTag{"source", "table"},
+		}, 1.0)
+
+		if d.SelectFingerprint {
+			if insertRowBatch, ok := batch.(InsertRowBatch); ok {
+				fingerprints := make(map[uint64][]byte)
+				rows := make([]RowData, batch.Size())
+
+				for i, rowData := range insertRowBatch.Values() {
+					paginationKey, err := rowData.GetUint64(insertRowBatch.PaginationKeyIndex())
+					if err != nil {
+						logger.WithError(err).Error("failed to get paginationKey data")
+						return err
+					}
+
+					fingerprints[paginationKey] = rowData[len(rowData)-1].([]byte)
+					rows[i] = rowData[:len(rowData)-1]
+				}
+
+				batch = &DataRowBatch{
+					values:             rows,
+					paginationKeyIndex: insertRowBatch.PaginationKeyIndex(),
+					table:              table,
+					fingerprints:       fingerprints,
+				}
+			}
+		}
+
+		for _, listener := range d.batchListeners {
+			err := listener(batch)
+			if err != nil {
+				logger.WithError(err).Error("failed to process row batch with listeners")
+				return err
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	logger.Debug("table iteration completed")
+	return nil
+}
+
+func (d *DataIterator) processUnpaginatedTable(table *TableSchema) error {
+	logger := d.logger.WithField("table", table.String())
+	logger.Debug("Starting full-table copy")
+
+	cursor := d.CursorConfig.NewFullTableCursor(table)
+	err := cursor.Each(func(batch RowBatch) error {
+		metrics.Count("RowEvent", int64(batch.Size()), []MetricTag{
+			MetricTag{"table", table.Name},
+			MetricTag{"source", "table"},
+		}, 1.0)
+
+		for _, listener := range d.batchListeners {
+			err := listener(batch)
+			if err != nil {
+				logger.WithError(err).Error("failed to process full-table row batch with listeners")
+				return err
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		logger.WithError(err).Error("failed to scan full table")
+		return err
+	}
+
+	logger.Debug("full table scan completed")
+	return nil
+}
+
+func (d *DataIterator) AddBatchListener(listener func(RowBatch) error) {
 	d.batchListeners = append(d.batchListeners, listener)
 }
 

--- a/inline_verifier.go
+++ b/inline_verifier.go
@@ -244,8 +244,13 @@ func (v *InlineVerifier) Result() (VerificationResultAndStatus, error) {
 	return VerificationResultAndStatus{}, nil
 }
 
-func (v *InlineVerifier) CheckFingerprintInline(tx *sql.Tx, targetSchema, targetTable string, sourceBatch *RowBatch) ([]uint64, error) {
+func (v *InlineVerifier) CheckFingerprintInline(tx *sql.Tx, targetSchema, targetTable string, sourceBatch InsertRowBatch) ([]uint64, error) {
 	table := sourceBatch.TableSchema()
+
+	if !sourceBatch.ValuesContainPaginationKey() {
+		v.logger.Debugf("skip fingerprint check on %s.%s", table.Schema, table.Name)
+		return nil, nil
+	}
 
 	paginationKeys := make([]uint64, len(sourceBatch.Values()))
 	for i, row := range sourceBatch.Values() {

--- a/row_batch.go
+++ b/row_batch.go
@@ -4,46 +4,70 @@ import (
 	"strings"
 )
 
-type RowBatch struct {
+type RowBatch interface {
+	TableSchema() *TableSchema
+	AsSQLQuery(schemaName, tableName string) (string, []interface{}, error)
+	Size() int
+	IsTableComplete() bool
+}
+
+type InsertRowBatch interface {
+	RowBatch
+	Values() []RowData
+	PaginationKeyIndex() int
+	ValuesContainPaginationKey() bool
+	Fingerprints() map[uint64][]byte
+}
+
+type DataRowBatch struct {
 	values             []RowData
 	paginationKeyIndex int
 	table              *TableSchema
 	fingerprints       map[uint64][]byte
 }
 
-func NewRowBatch(table *TableSchema, values []RowData, paginationKeyIndex int) *RowBatch {
-	return &RowBatch{
+func NewDataRowBatch(table *TableSchema, values []RowData) *DataRowBatch {
+	return NewDataRowBatchWithPaginationKey(table, values, -1)
+}
+
+func NewDataRowBatchWithPaginationKey(table *TableSchema, values []RowData, paginationKeyIndex int) *DataRowBatch {
+	return &DataRowBatch{
 		values:             values,
 		paginationKeyIndex: paginationKeyIndex,
 		table:              table,
 	}
 }
 
-func (e *RowBatch) Values() []RowData {
+func (e *DataRowBatch) Values() []RowData {
 	return e.values
 }
 
-func (e *RowBatch) PaginationKeyIndex() int {
+func (e *DataRowBatch) PaginationKeyIndex() int {
 	return e.paginationKeyIndex
 }
 
-func (e *RowBatch) ValuesContainPaginationKey() bool {
+func (e *DataRowBatch) ValuesContainPaginationKey() bool {
 	return e.paginationKeyIndex >= 0
 }
 
-func (e *RowBatch) Size() int {
+func (e *DataRowBatch) Size() int {
 	return len(e.values)
 }
 
-func (e *RowBatch) TableSchema() *TableSchema {
+func (e *DataRowBatch) IsTableComplete() bool {
+	// we currently always use a dedicated batch for marking completion
+	return false
+}
+
+func (e *DataRowBatch) TableSchema() *TableSchema {
 	return e.table
 }
 
-func (e *RowBatch) Fingerprints() map[uint64][]byte {
+func (e *DataRowBatch) Fingerprints() map[uint64][]byte {
 	return e.fingerprints
 }
 
-func (e *RowBatch) AsSQLQuery(schemaName, tableName string) (string, []interface{}, error) {
+func (e *DataRowBatch) AsSQLQuery(schemaName, tableName string) (string, []interface{}, error) {
 	if err := verifyValuesHasTheSameLengthAsColumns(e.table, e.values...); err != nil {
 		return "", nil, err
 	}
@@ -60,7 +84,7 @@ func (e *RowBatch) AsSQLQuery(schemaName, tableName string) (string, []interface
 	return query, e.flattenRowData(), nil
 }
 
-func (e *RowBatch) flattenRowData() []interface{} {
+func (e *DataRowBatch) flattenRowData() []interface{} {
 	rowSize := len(e.values[0])
 	flattened := make([]interface{}, rowSize*len(e.values))
 
@@ -71,4 +95,59 @@ func (e *RowBatch) flattenRowData() []interface{} {
 	}
 
 	return flattened
+}
+
+type TruncateTableBatch struct {
+	table *TableSchema
+}
+
+func NewTruncateTableBatch(table *TableSchema) *TruncateTableBatch {
+	return &TruncateTableBatch{table}
+}
+
+func (e *TruncateTableBatch) TableSchema() *TableSchema {
+	return e.table
+}
+
+func (e *TruncateTableBatch) Size() int {
+	return 1
+}
+
+func (e *TruncateTableBatch) IsTableComplete() bool {
+	// we currently always use a dedicated batch for marking completion
+	return false
+}
+
+func (e *TruncateTableBatch) AsSQLQuery(schemaName, tableName string) (string, []interface{}, error) {
+	quotedTableName := QuotedTableNameFromString(schemaName, tableName)
+	quotedTableName = strings.Replace(quotedTableName, "*/", "", -1)
+	query := "TRUNCATE /* ghostferry initialize table " + quotedTableName + " */ TABLE " + quotedTableName
+	return query, nil, nil
+}
+
+type FinalizeTableCopyBatch struct {
+	table *TableSchema
+}
+
+func NewFinalizeTableCopyBatch(table *TableSchema) *FinalizeTableCopyBatch {
+	return &FinalizeTableCopyBatch{table}
+}
+
+func (e *FinalizeTableCopyBatch) TableSchema() *TableSchema {
+	return e.table
+}
+
+func (e *FinalizeTableCopyBatch) Size() int {
+	return 1
+}
+
+func (e *FinalizeTableCopyBatch) IsTableComplete() bool {
+	return true
+}
+
+func (e *FinalizeTableCopyBatch) AsSQLQuery(schemaName, tableName string) (string, []interface{}, error) {
+	quotedTableName := QuotedTableNameFromString(schemaName, tableName)
+	quotedTableName = strings.Replace(quotedTableName, "*/", "", -1)
+	query := "SELECT /* ghostferry finalize table " + quotedTableName + " */ 1"
+	return query, nil, nil
 }

--- a/test/go/data_iterator_test.go
+++ b/test/go/data_iterator_test.go
@@ -59,8 +59,17 @@ func (this *DataIteratorTestSuite) SetupTest() {
 
 	this.receivedRows = make(map[string][]ghostferry.RowData, 0)
 
-	this.di.AddBatchListener(func(ev *ghostferry.RowBatch) error {
-		this.receivedRows[ev.TableSchema().Name] = append(this.receivedRows[ev.TableSchema().Name], ev.Values()...)
+	this.di.AddBatchListener(func(b ghostferry.RowBatch) error {
+		switch ev := b.(type) {
+		case ghostferry.InsertRowBatch:
+			if b.Size() > 0 {
+				this.receivedRows[ev.TableSchema().Name] = append(this.receivedRows[ev.TableSchema().Name], ev.Values()...)
+			}
+		}
+		// do what the batch-writer would do: mark the table as done
+		if b.IsTableComplete() {
+			this.di.StateTracker.MarkTableAsCompleted(b.TableSchema().String())
+		}
 		return nil
 	})
 }

--- a/test/go/data_iterator_test.go
+++ b/test/go/data_iterator_test.go
@@ -14,10 +14,11 @@ import (
 type DataIteratorTestSuite struct {
 	*testhelpers.GhostferryUnitTestSuite
 
-	di           *ghostferry.DataIterator
-	wg           *sync.WaitGroup
-	tables       []*ghostferry.TableSchema
-	receivedRows map[string][]ghostferry.RowData
+	di                  *ghostferry.DataIterator
+	wg                  *sync.WaitGroup
+	tables              []*ghostferry.TableSchema
+	receivedRows        map[string][]ghostferry.RowData
+	receivedRowsRWMutex *sync.RWMutex
 }
 
 func (this *DataIteratorTestSuite) SetupTest() {
@@ -58,11 +59,17 @@ func (this *DataIteratorTestSuite) SetupTest() {
 	}
 
 	this.receivedRows = make(map[string][]ghostferry.RowData, 0)
+	this.receivedRowsRWMutex = &sync.RWMutex{}
 
 	this.di.AddBatchListener(func(b ghostferry.RowBatch) error {
 		switch ev := b.(type) {
 		case ghostferry.InsertRowBatch:
 			if b.Size() > 0 {
+				// it's possible that the paginated and unpaginated tables are
+				// copied in parallel. Serialize access to the map
+				this.receivedRowsRWMutex.RLock()
+				defer this.receivedRowsRWMutex.RUnlock()
+
 				this.receivedRows[ev.TableSchema().Name] = append(this.receivedRows[ev.TableSchema().Name], ev.Values()...)
 			}
 		}

--- a/test/go/race_conditions_integration_test.go
+++ b/test/go/race_conditions_integration_test.go
@@ -23,7 +23,12 @@ func TestSelectUpdateBinlogCopy(t *testing.T) {
 		Ferry:       testhelpers.NewTestFerry(),
 	}
 
-	testcase.Ferry.BeforeBatchCopyListener = func(batch *ghostferry.RowBatch) error {
+	testcase.Ferry.BeforeBatchCopyListener = func(rowBatch ghostferry.RowBatch) error {
+		batch, ok := rowBatch.(ghostferry.InsertRowBatch)
+		if !ok {
+			return nil
+		}
+
 		queries := make([]string, len(batch.Values()))
 		for i, row := range batch.Values() {
 			id := row[0].(int64)
@@ -138,7 +143,7 @@ func TestOnlyDeleteRowWithMaxPaginationKey(t *testing.T) {
 	testcase.Ferry.DataIterationBatchSize = 1
 
 	lastRowDeleted := false
-	testcase.Ferry.BeforeBatchCopyListener = func(batch *ghostferry.RowBatch) error {
+	testcase.Ferry.BeforeBatchCopyListener = func(batch ghostferry.RowBatch) error {
 		if lastRowDeleted {
 			return nil
 		}

--- a/test/helpers/ghostferry_helper.rb
+++ b/test/helpers/ghostferry_helper.rb
@@ -124,6 +124,14 @@ module GhostferryHelper
       raise "Ghostferry did not get interrupted"
     end
 
+    def run_expecting_crash(resuming_state = nil)
+      run(resuming_state)
+    rescue GhostferryExitFailure
+      return @stdout.join("\n"), @stderr.join("\n")
+    else
+      raise "Ghostferry did not crash"
+    end
+
     ######################################################
     # Methods representing the different stages of `run` #
     ######################################################

--- a/test/integration/full_table_copy_test.rb
+++ b/test/integration/full_table_copy_test.rb
@@ -1,0 +1,64 @@
+require "test_helper"
+
+class FullTableCopyTest < GhostferryTestCase
+  def test_reject_table_with_string_primary_key
+    define_test_table_with_data("data varchar(32), primary key(data)")
+
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY)
+    _, stderr = ghostferry.run_expecting_crash
+    assert_includes stderr, "panic: Pagination Key `data` for `gftest`.`test_table_1` is non-numeric"
+  end
+
+  def test_reject_table_without_primary_key
+    define_test_table_with_data("data varchar(32)")
+
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY)
+    _, stderr = ghostferry.run_expecting_crash
+    assert_includes stderr, "panic: `gftest`.`test_table_1` has no Primary Key to default to for Pagination purposes"
+  end
+
+  def test_copy_table_with_string_primary_key
+    define_test_table_with_data("data varchar(32), primary key(data)")
+
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY, config: {
+        cascading_pagination_column_config: {
+            FullTableCopies: {
+                DEFAULT_DB => [
+                    DEFAULT_TABLE,
+                ],
+            },
+        }.to_json,
+    })
+    ghostferry.run
+
+    assert_test_table_is_identical
+  end
+
+  def test_copy_table_without_primary_key
+    define_test_table_with_data("data varchar(32)")
+
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY, config: {
+        cascading_pagination_column_config: {
+            FullTableCopies: {
+                DEFAULT_DB => [
+                    DEFAULT_TABLE,
+                ],
+            },
+        }.to_json,
+    })
+    ghostferry.run
+
+    assert_test_table_is_identical
+  end
+
+  private
+
+  def define_test_table_with_data(column_definition)
+    [source_db, target_db].each do |db|
+      db.query("CREATE DATABASE IF NOT EXISTS #{DEFAULT_DB}")
+      db.query("CREATE TABLE IF NOT EXISTS #{DEFAULT_FULL_TABLE_NAME} (#{column_definition})")
+    end
+
+    source_db.query("INSERT INTO #{DEFAULT_FULL_TABLE_NAME} (data) VALUES ('data1'), ('data2')")
+  end
+end

--- a/test/integration/interrupt_resume_test.rb
+++ b/test/integration/interrupt_resume_test.rb
@@ -31,7 +31,11 @@ class InterruptResumeTest < GhostferryTestCase
     result = target_db.query("SELECT MAX(id) AS max_id FROM #{DEFAULT_FULL_TABLE_NAME}")
     last_successful_id = result.first["max_id"]
     assert last_successful_id > 0
-    assert_equal last_successful_id, dumped_state["LastSuccessfulPaginationKeys"]["#{DEFAULT_DB}.#{DEFAULT_TABLE}"]
+    # NOTE: Ideally the resume data in the target database would match the data
+    # in the resume state exactly, but there is a race condition between
+    # committing the data transaction and updating the resume data.
+    # See comments in batch_writer.go on committing the transaction for details.
+    assert_operator last_successful_id, :>=, dumped_state["LastSuccessfulPaginationKeys"]["#{DEFAULT_DB}.#{DEFAULT_TABLE}"]
   end
 
   def test_interrupt_and_resume_without_last_known_schema_cache

--- a/test/lib/go/integrationferry.go
+++ b/test/lib/go/integrationferry.go
@@ -77,7 +77,7 @@ func (f *IntegrationFerry) SendStatusAndWaitUntilContinue(status string, data ..
 // Method override for Start in order to send status to the integration
 // server.
 func (f *IntegrationFerry) Start() error {
-	f.Ferry.DataIterator.AddBatchListener(func(rowBatch *ghostferry.RowBatch) error {
+	f.Ferry.DataIterator.AddBatchListener(func(rowBatch ghostferry.RowBatch) error {
 		return f.SendStatusAndWaitUntilContinue(StatusBeforeRowCopy, rowBatch.TableSchema().Name)
 	})
 
@@ -90,7 +90,7 @@ func (f *IntegrationFerry) Start() error {
 		return err
 	}
 
-	f.Ferry.DataIterator.AddBatchListener(func(rowBatch *ghostferry.RowBatch) error {
+	f.Ferry.DataIterator.AddBatchListener(func(rowBatch ghostferry.RowBatch) error {
 		return f.SendStatusAndWaitUntilContinue(StatusAfterRowCopy, rowBatch.TableSchema().Name)
 	})
 

--- a/testhelpers/test_ferry.go
+++ b/testhelpers/test_ferry.go
@@ -10,11 +10,11 @@ import (
 type TestFerry struct {
 	*ghostferry.Ferry
 
-	BeforeBatchCopyListener   func(batch *ghostferry.RowBatch) error
+	BeforeBatchCopyListener   func(batch ghostferry.RowBatch) error
 	BeforeBinlogApplyListener func(events []ghostferry.DMLEvent) error
 	BeforeRowCopyDoneListener func() error
 
-	AfterBatchCopyListener   func(batch *ghostferry.RowBatch) error
+	AfterBatchCopyListener   func(batch ghostferry.RowBatch) error
 	AfterBinlogApplyListener func(events []ghostferry.DMLEvent) error
 	AfterRowCopyDoneListener func() error
 }


### PR DESCRIPTION
This commit adds the ability to mark tables as "full-table copy" tables,
for which we copy all table rows using a simple SQL table "offset",
allowing to copy (small) tables that do not have indices we can use to
iterate on.

To guarantee correct copy behavior, the source table is locked for the
entire copy procedure, making this viable only for small tables.

Change-Id: Ie009175d94fe9d2c4fd75b63e91243e2260b909d