### PR TITLE
Fix for logging resume-state in config #163 (#9)

### DIFF
--- a/copydb/cmd/main.go
+++ b/copydb/cmd/main.go
@@ -91,7 +91,9 @@ func main() {
 		// the filename in the config *and* specify it as command line, in which
 		// case we'll resume from the CLI argument and write to the config file,
 		// but fail if the former does not exist
-		if _, err := os.Stat(config.Config.StateFilename); !os.IsNotExist(err) {
+		if config.Config.StateFilename == "" {
+			logger.Debug("No state file specified in config")
+		} else if _, err := os.Stat(config.Config.StateFilename); !os.IsNotExist(err) {
 			stateFilePath = config.Config.StateFilename
 			logger.Infof("Reading state information from file specified in config: %s", stateFilePath)
 		} else {


### PR DESCRIPTION
An earlier commit introduced the ability to specify the resume-state
file in the configuration - reading the file if it exists and ignoring
if it did not.
This commit removes a log message saying that the file cannot be found
if the file is not specified in the config.

Change-Id: Iebfafd1513f4b2397e965efd96932c1824751576