### PR TITLE
Move AllowReplicationFromReplica into config

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ Features/fixes added in this fork include
     - database/table name rewrites are not supported, as we would need non-
       trivial rewrites of schema changing statements when tables are altered,
       renamed, created, or deleted.
+- support [reading from (read-only) DB replica](https://github.com/Lastline-Inc/ghostferry/issues/22):
+  under certain conditions, replicating data from a DB slave may be safe and
+  required. Furthermore, it may not be possible to lock inserts on the source
+  from the context of ghostferry.
+  A set of optional flags allow disabling locking and checking for replication
+  delay when reading from the source, if the user knows that the operation is
+  safe.
 
 Overview of How it Works
 ------------------------

--- a/config.go
+++ b/config.go
@@ -464,6 +464,35 @@ type Config struct {
 	// Optional: defaults to false
 	ReplicateSchemaChanges bool
 
+	// For migrating data, it is crucial that we're either reading from a master
+	// or from a slave that is up-to-date with its master. If we are just
+	// continuously replicating/streaming data, it's OK to work on an outdated
+	// upstream
+	//
+	// Optional: defaults to false
+	AllowReplicationFromReplica bool
+
+	// When copying a table with pagination, do not lock the source table for
+	// inserts. This may be an unsafe operation if the source table may be
+	// deleted from.
+	// Use only if the application guarantees that no rows are deleted from the
+	// tables that are copied with pagination.
+	//
+	// Optional: defaults to false
+	CopyPaginatedTablesWithoutLock bool
+
+	// When copying a table without pagination ("full table" copies), do not
+	// lock the source table for inserts. This is an unsafe operation if the
+	// source table may be deleted from, as the copy may skip over rows, but
+	// it may be a requirement if the source DB is read-only (and thus locking
+	// is not possible).
+	// Use only if the application guarantees that no rows are deleted from the
+	// tables that are copied without pagination, or if tables are smaller than
+	// the batch size (in which case no locking is needed).
+	//
+	// Optional: defaults to false
+	CopyUnpaginatedTablesWithoutLock bool
+
 	// This specifies whether or not Ferry.Run will handle SIGINT and SIGTERM
 	// by dumping the current state to stdout and the error HTTP callback.
 	// The dumped state can be used to resume Ghostferry.

--- a/ferry.go
+++ b/ferry.go
@@ -70,10 +70,6 @@ type Ferry struct {
 	ErrorHandler                       ErrorHandler
 	Throttler                          Throttler
 	WaitUntilReplicaIsCaughtUpToMaster *WaitUntilReplicaIsCaughtUpToMaster
-	// For migrating data, it is crucial that we're either reading from a master or from a slave
-	// that is up-to-date with its master. If we are just continuously repliating/streaming data,
-	// it's OK to work on an outdated upstream
-	AllowReplicationFromReplia         bool
 
 	// This can be specified by the caller. If specified, do not specify
 	// VerifierType in Config (or as an empty string) or an error will be
@@ -380,7 +376,7 @@ func (f *Ferry) Initialize() (err error) {
 			f.logger.WithError(err).Error("source master is a read replica")
 			return err
 		}
-	} else if !f.AllowReplicationFromReplia {
+	} else if !f.AllowReplicationFromReplica {
 		isReplica, err := CheckDbIsAReplica(f.SourceDB)
 		if err != nil {
 			f.logger.WithError(err).Error("cannot check if source is a replica")

--- a/replicatedb/replicatedb.go
+++ b/replicatedb/replicatedb.go
@@ -13,7 +13,6 @@ type ReplicatedbFerry struct {
 func NewFerry(config *Config) *ReplicatedbFerry {
 	ferry := &ghostferry.Ferry{
 		Config: config.Config,
-		AllowReplicationFromReplia: true,
 	}
 
 	return &ReplicatedbFerry{

--- a/test/lib/go/integrationferry.go
+++ b/test/lib/go/integrationferry.go
@@ -205,6 +205,7 @@ func NewStandardConfig() (*ghostferry.Config, error) {
 		},
 
 		AutomaticCutover: true,
+		FailOnFirstTableCopyError: true,
 		TableFilter: &testhelpers.TestTableFilter{
 			DbsFunc:    testhelpers.DbApplicabilityFilter([]string{"gftest"}),
 			TablesFunc: nil,


### PR DESCRIPTION
This commit moves the flag for allowing repliction from a slave DB from
the Ferry object into the Config object to allow enabling it for copydb
via the config.

Change-Id: I0040b75671317ce355a32c4528159367835cb513