### PR TITLE
Introduce "Lock Strategy" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,14 +92,14 @@ Features/fixes added in this fork include
       trivial rewrites of schema changing statements when tables are altered,
       renamed, created, or deleted.
 - support [reading from (read-only) DB replica](https://github.com/Lastline-Inc/ghostferry/issues/22):
-  under certain conditions, replicating data from a DB slave may be safe and
-  required. Furthermore, it may not be possible to lock inserts on the source
-  from the context of ghostferry.
-  A set of optional flags allow disabling locking and checking for replication
-  delay when reading from the source, if the user knows that the operation is
-  safe.
+  allow using locks within `Ghostferry` (instead of on the source database) to
+  avoid race conditions between the data copy and binlog replication. The
+  upstream version of `Ghostferry` locks tables on the source, potentially
+  interferring with the application. Furthermore, by using locks outside the
+  DB, it is possible to replicate from read-only sources where locking is not
+  an option (e.g., cloud-SQL).
 - support [non-int primary keys](https://github.com/Lastline-Inc/ghostferry/issues/24):
-  Extend `Ghostferry` to support signed/unsigned integers, string, and
+  extend `Ghostferry` to support signed/unsigned integers, string, and
   composite primary keys (that use ints and strings). This vastly reduces the
   types of tables for which "full copy" is required.  
   Additionally support iterating over table rows to copy in descending order.

--- a/binlog_writer.go
+++ b/binlog_writer.go
@@ -392,7 +392,7 @@ func (b *BinlogWriter) writeEvents(events []DXLEventWrapper) error {
 		// for DML events, we need to make sure we synchronize with the
 		// data-iterator - for details on why, see the corresponding
 		// data-iterator code
-		if b.LockStrategy == LockTypeInGhostferry {
+		if b.LockStrategy == LockStrategyInGhostferry {
 			if dmlEvent, ok := ev.DXLEvent.(DMLEvent); ok {
 				fullTableName := dmlEvent.TableSchema().Table.String()
 				if _, found := locksToObtain[fullTableName]; !found {

--- a/config.go
+++ b/config.go
@@ -20,9 +20,9 @@ const (
 	VerifierTypeInline         = "Inline"
 	VerifierTypeNoVerification = "NoVerification"
 
-	LockTypeSourceDB = "LockOnSourceDB"
-	LockTypeInGhostferry = "LockInGhostferry"
-	LockTypeNone = "None"
+	LockStrategySourceDB     = "LockOnSourceDB"
+	LockStrategyInGhostferry = "LockInGhostferry"
+	LockStrategyNone         = "None"
 )
 
 type TLSConfig struct {
@@ -654,8 +654,8 @@ func (c *Config) ValidateConfig() error {
 	}
 
 	if c.LockStrategy == "" {
-		c.LockStrategy = LockTypeSourceDB
-	} else if c.LockStrategy != LockTypeSourceDB && c.LockStrategy != LockTypeInGhostferry && c.LockStrategy != LockTypeNone {
+		c.LockStrategy = LockStrategySourceDB
+	} else if c.LockStrategy != LockStrategySourceDB && c.LockStrategy != LockStrategyInGhostferry && c.LockStrategy != LockStrategyNone {
 		return fmt.Errorf("Invalid LockStrategy specified (set to %s)", c.LockStrategy)
 	}
 

--- a/config.go
+++ b/config.go
@@ -19,6 +19,10 @@ const (
 	VerifierTypeIterative      = "Iterative"
 	VerifierTypeInline         = "Inline"
 	VerifierTypeNoVerification = "NoVerification"
+
+	LockTypeSourceDB = "LockOnSourceDB"
+	LockTypeInGhostferry = "LockInGhostferry"
+	LockTypeNone = "None"
 )
 
 type TLSConfig struct {
@@ -483,26 +487,20 @@ type Config struct {
 	// Optional: defaults to false
 	AllowReplicationFromReplica bool
 
-	// When copying a table with pagination, do not lock the source table for
-	// inserts. This may be an unsafe operation if the source table may be
-	// deleted from.
-	// Use only if the application guarantees that no rows are deleted from the
-	// tables that are copied with pagination.
+	// This specifies how to prevent races between the data copy and binlog
+	// streaming. Possible values are:
+	// - LockOnSourceDB: obtain a table lock on the source table while copying
+	//   data, which will prevent any type of data modification on the source
+	//   DB; this is the strictest method but may intervene with the
+	//   application trying to insert data,
+	// - LockInGhostferry: obtain a lock in ghostferry, preventing updates to
+	//   the target DB while copying data; this should be sufficient in most
+	//   scenarios, and
+	// - None: do not perform locking, assume the application does not update
+	//   or delete data in a way that races may occur.
 	//
-	// Optional: defaults to false
-	CopyPaginatedTablesWithoutLock bool
-
-	// When copying a table without pagination ("full table" copies), do not
-	// lock the source table for inserts. This is an unsafe operation if the
-	// source table may be deleted from, as the copy may skip over rows, but
-	// it may be a requirement if the source DB is read-only (and thus locking
-	// is not possible).
-	// Use only if the application guarantees that no rows are deleted from the
-	// tables that are copied without pagination, or if tables are smaller than
-	// the batch size (in which case no locking is needed).
-	//
-	// Optional: defaults to false
-	CopyUnpaginatedTablesWithoutLock bool
+	// Optional: defaults to "LockOnSourceDB"
+	LockStrategy string
 
 	// This specifies whether or not Ferry.Run will handle SIGINT and SIGTERM
 	// by dumping the current state to stdout and the error HTTP callback.
@@ -653,6 +651,12 @@ func (c *Config) ValidateConfig() error {
 		if err := c.InlineVerifierConfig.Validate(); err != nil {
 			return fmt.Errorf("InlineVerifierConfig invalid: %v", err)
 		}
+	}
+
+	if c.LockStrategy == "" {
+		c.LockStrategy = LockTypeSourceDB
+	} else if c.LockStrategy != LockTypeSourceDB && c.LockStrategy != LockTypeInGhostferry && c.LockStrategy != LockTypeNone {
+		return fmt.Errorf("Invalid LockStrategy specified (set to %s)", c.LockStrategy)
 	}
 
 	if c.DBWriteRetries == 0 {

--- a/data_iterator.go
+++ b/data_iterator.go
@@ -276,11 +276,11 @@ func (d *DataIterator) processPaginatedTable(table *TableSchema) error {
 	// source data is not modified between reading from the source and writing
 	// the batch to the target.
 	var cursor *PaginatedCursor
-	if d.lockStrategy == LockTypeSourceDB {
+	if d.lockStrategy == LockStrategySourceDB {
 		cursor = d.CursorConfig.NewPaginatedCursor(table, startPaginationKeyData, targetPaginationKeyData)
 	} else {
 		var tableLock *sync.RWMutex
-		if d.lockStrategy == LockTypeInGhostferry {
+		if d.lockStrategy == LockStrategyInGhostferry {
 			tableLock = d.StateTracker.GetTableLock(table.String())
 		}
 		cursor = d.CursorConfig.NewPaginatedCursorWithoutRowLock(table, startPaginationKeyData, targetPaginationKeyData, tableLock)
@@ -346,10 +346,10 @@ func (d *DataIterator) processUnpaginatedTable(table *TableSchema) error {
 	logger.Debug("Starting full-table copy")
 
 	var tableLock *sync.RWMutex
-	if d.lockStrategy == LockTypeInGhostferry {
+	if d.lockStrategy == LockStrategyInGhostferry {
 		tableLock = d.StateTracker.GetTableLock(table.String())
 	}
-	cursor := d.CursorConfig.NewFullTableCursor(table, d.lockStrategy == LockTypeSourceDB, tableLock)
+	cursor := d.CursorConfig.NewFullTableCursor(table, d.lockStrategy == LockStrategySourceDB, tableLock)
 
 	err := cursor.Each(func(batch RowBatch) error {
 		metrics.Count("RowEvent", int64(batch.Size()), []MetricTag{

--- a/examples/copydb/cloud-sql-conf.json
+++ b/examples/copydb/cloud-sql-conf.json
@@ -1,7 +1,7 @@
 {
   "Source": {
     "Host": "127.0.0.1",
-    "Port": 29292,
+    "Port": 29291,
     "User": "root",
     "Pass": "",
     "Collation": "utf8mb4_unicode_ci",
@@ -12,7 +12,7 @@
 
   "Target": {
     "Host": "127.0.0.1",
-    "Port": 29293,
+    "Port": 29292,
     "User": "root",
     "Pass": "",
     "Collation": "utf8mb4_unicode_ci",
@@ -20,21 +20,6 @@
       "charset": "utf8mb4"
     }
   },
-
-  "RunFerryFromReplica": true,
-
-  "SourceReplicationMaster": {
-    "Host": "127.0.0.1",
-    "Port": 29291,
-    "User": "root",
-    "Pass": "",
-    "Collation": "utf8mb4_unicode_ci",
-    "Params": {
-      "charset": "utf8mb4"
-    }
-  },
-
-  "ReplicatedMasterPositionQuery": "SELECT file, position FROM meta.heartbeat",
 
   "Databases": {
     "Whitelist": ["abc"]
@@ -44,5 +29,11 @@
     "Blacklist": ["schema_migrations"]
   },
 
-  "VerifierType": "ChecksumTable"
+  "DBReadRetries": 3,
+  "DumpStateOnSignal": false,
+  "ResumeStateFromDB": "_ghostferry",
+  "ForceResumeStateUpdatesToDB": true,
+
+  "AllowReplicationFromReplica": true,
+  "LockStrategy": "LockInGhostferry"
 }

--- a/examples/copydb/run-on-replica.conf.json
+++ b/examples/copydb/run-on-replica.conf.json
@@ -22,7 +22,6 @@
   },
 
   "RunFerryFromReplica": true,
-
   "SourceReplicationMaster": {
     "Host": "127.0.0.1",
     "Port": 29291,

--- a/ferry.go
+++ b/ferry.go
@@ -133,6 +133,7 @@ func (f *Ferry) NewBinlogWriter() *BinlogWriter {
 		BatchSize:          f.Config.BinlogEventBatchSize,
 		WriteRetries:       f.Config.DBWriteRetries,
 		ApplySchemaChanges: f.Config.ReplicateSchemaChanges,
+		LockStrategy:       f.Config.LockStrategy,
 
 		ErrorHandler:                f.ErrorHandler,
 		StateTracker:                f.StateTracker,

--- a/iterative_verifier.go
+++ b/iterative_verifier.go
@@ -389,7 +389,7 @@ func (v *IterativeVerifier) iterateAllTables(mismatchedPaginationKeyFunc func(ui
 func (v *IterativeVerifier) iterateTableFingerprints(table *TableSchema, mismatchedPaginationKeyFunc func(uint64, *TableSchema) error) error {
 	// The cursor will stop iterating when it cannot find anymore rows,
 	// so it will not iterate until MaxUint64.
-	cursor := v.CursorConfig.NewPaginatedCursorWithoutRowLock(table, nil, nil)
+	cursor := v.CursorConfig.NewPaginatedCursorWithoutRowLock(table, nil, nil, nil)
 
 	// It only needs the PaginationKeys, not the entire row.
 	cursor.ColumnsToSelect = []string{fmt.Sprintf("`%s`", table.PaginationKey.Columns[0].Name)}

--- a/state_tracker.go
+++ b/state_tracker.go
@@ -233,6 +233,9 @@ func (s *StateTracker) GetTableLock(table string) *sync.RWMutex {
 	s.CopyRWMutex.Lock()
 	defer s.CopyRWMutex.Unlock()
 
+	// table locks are needed only for synchronizing data copy and binlog
+	// writing. We optimize this into a NULL-lock if we know this race is
+	// not possible
 	if s.completedTables[table] {
 		return nil
 	}

--- a/state_tracker.go
+++ b/state_tracker.go
@@ -92,6 +92,7 @@ type StateTracker struct {
 
 	lastSuccessfulPaginationKeys map[string]*PaginationKeyData
 	completedTables              map[string]bool
+	tableLocks                   map[string]*sync.RWMutex
 
 	// optional database+table prefix to which we write the current status
 	stateTablesPrefix string
@@ -107,6 +108,7 @@ func NewStateTracker(speedLogCount int) *StateTracker {
 
 		lastSuccessfulPaginationKeys: make(map[string]*PaginationKeyData),
 		completedTables:              make(map[string]bool),
+		tableLocks:                   make(map[string]*sync.RWMutex),
 		logger:                       logrus.WithField("tag", "state_tracker"),
 		iterationSpeedLog:            newSpeedLogRing(speedLogCount),
 	}
@@ -225,6 +227,23 @@ func (s *StateTracker) IsTableComplete(table string) bool {
 	defer s.CopyRWMutex.RUnlock()
 
 	return s.completedTables[table]
+}
+
+func (s *StateTracker) GetTableLock(table string) *sync.RWMutex {
+	s.CopyRWMutex.Lock()
+	defer s.CopyRWMutex.Unlock()
+
+	if s.completedTables[table] {
+		return nil
+	}
+
+	if lock, found := s.tableLocks[table]; found {
+		return lock
+	}
+
+	lock := &sync.RWMutex{}
+	s.tableLocks[table] = lock
+	return lock
 }
 
 // This is reasonably accurate if the rows copied are distributed uniformly

--- a/test/helpers/ghostferry_helper.rb
+++ b/test/helpers/ghostferry_helper.rb
@@ -258,6 +258,7 @@ module GhostferryHelper
 
         if @config[:iterate_in_descending_order]
           environment["GHOSTFERRY_ITERATE_IN_DESCENDING_ORDER"] = "true"
+        end
 
         if @config[:lock_strategy]
           environment["GHOSTFERRY_LOCK_STRATEGY"] = @config[:lock_strategy]

--- a/test/helpers/ghostferry_helper.rb
+++ b/test/helpers/ghostferry_helper.rb
@@ -258,6 +258,9 @@ module GhostferryHelper
 
         if @config[:iterate_in_descending_order]
           environment["GHOSTFERRY_ITERATE_IN_DESCENDING_ORDER"] = "true"
+
+        if @config[:lock_strategy]
+          environment["GHOSTFERRY_LOCK_STRATEGY"] = @config[:lock_strategy]
         end
 
         @logger.info("starting ghostferry test binary #{@compiled_binary_path}")

--- a/test/integration/trivial_test.rb
+++ b/test/integration/trivial_test.rb
@@ -108,4 +108,13 @@ class TrivialIntegrationTests < GhostferryTestCase
       end
     end
   end
+
+  def test_lock_strategy_in_ghostferry
+    seed_simple_database_with_single_table
+
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY, config: { lock_strategy: "LockInGhostferry" })
+    ghostferry.run
+
+    assert_test_table_is_identical
+  end
 end

--- a/test/lib/go/integrationferry.go
+++ b/test/lib/go/integrationferry.go
@@ -282,6 +282,10 @@ func NewStandardConfig() (*ghostferry.Config, error) {
 		}
 	}
 
+	if lockStrategy := os.Getenv("GHOSTFERRY_LOCK_STRATEGY"); lockStrategy != "" {
+		config.LockStrategy = lockStrategy
+	}
+
 	return config, config.ValidateConfig()
 }
 


### PR DESCRIPTION
With this commit, we allow using an in-application lock in ghostferry,
instead of using the source DB as lock. The lock is required to avoid
race conditions between the data iteration/copy and the binlog writer.

The default behavior is preserved; a new option LockStrategy allows
moving the lock from the source DB into ghostferry, or disabling the
lock altogether.

This fixes #24