### PR TITLE
Allow pausing throttlers separtely

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ Features/fixes added in this fork include
       configurable to provide the legacy behavior.
 - more robust [disabling of inline-verifier](https://github.com/Shopify/ghostferry/issues/184):
   this fix has not made it into upstream master yet.
+- support throttling of data migration separately from replication. This allows
+  prioritizing the data replication over the copy of old data (or vice-versa).
 
 Overview of How it Works
 ------------------------

--- a/data_iterator.go
+++ b/data_iterator.go
@@ -34,7 +34,7 @@ func NewDataIterator(f *Ferry) *DataIterator {
 		ErrorHandler: f.ErrorHandler,
 		CursorConfig: &CursorConfig{
 			DB:        f.SourceDB,
-			Throttler: f.Throttler,
+			Throttler: f.MigrationThrottler,
 
 			BatchSize:   f.Config.DataIterationBatchSize,
 			ReadRetries: f.Config.DBReadRetries,

--- a/sharding/sharding.go
+++ b/sharding/sharding.go
@@ -135,7 +135,8 @@ func (r *ShardingFerry) Run() {
 		r.Ferry.ErrorHandler.Fatal("sharding", err)
 	}
 
-	r.Ferry.Throttler.SetDisabled(true)
+	r.Ferry.MigrationThrottler.SetDisabled(true)
+	r.Ferry.ReplicationThrottler.SetDisabled(true)
 
 	r.Ferry.FlushBinlogAndStopStreaming()
 	copyWG.Wait()
@@ -172,7 +173,8 @@ func (r *ShardingFerry) Run() {
 		r.Ferry.ErrorHandler.Fatal("sharding", err)
 	}
 
-	r.Ferry.Throttler.SetDisabled(false)
+	r.Ferry.MigrationThrottler.SetDisabled(false)
+	r.Ferry.ReplicationThrottler.SetDisabled(false)
 
 	metrics.Measure("CutoverUnlock", nil, 1.0, func() {
 		err = r.config.CutoverUnlock.Post(&client)

--- a/sharding/sharding.go
+++ b/sharding/sharding.go
@@ -56,8 +56,9 @@ func NewFerry(config *Config) (*ShardingFerry, error) {
 	}
 
 	ferry := &ghostferry.Ferry{
-		Config:    config.Config,
-		Throttler: throttler,
+		Config:               config.Config,
+		MigrationThrottler:   throttler,
+		ReplicationThrottler: throttler,
 	}
 
 	logger := logrus.WithField("tag", "sharding")
@@ -107,7 +108,8 @@ func (r *ShardingFerry) Run() {
 
 	r.Ferry.WaitUntilRowCopyIsComplete()
 
-	ghostferry.WaitForThrottle(r.Ferry.Throttler)
+	ghostferry.WaitForThrottle(r.Ferry.MigrationThrottler)
+	ghostferry.WaitForThrottle(r.Ferry.ReplicationThrottler)
 
 	r.Ferry.WaitUntilBinlogStreamerCatchesUp()
 

--- a/status_deprecated.go
+++ b/status_deprecated.go
@@ -39,7 +39,10 @@ type StatusDeprecated struct {
 	LastSuccessfulBinlogPos     mysql.Position
 	TargetBinlogPos             mysql.Position
 
+	// for backwards compatibility, a union of the detailed stats below
 	Throttled bool
+	MigrationThrottled bool
+	ReplicationThrottled bool
 
 	CompletedTableCount int
 	TotalTableCount     int
@@ -93,7 +96,9 @@ func FetchStatusDeprecated(f *Ferry, v Verifier) *StatusDeprecated {
 	status.LastSuccessfulBinlogPos = f.BinlogStreamer.GetLastStreamedBinlogPosition()
 	status.TargetBinlogPos = f.BinlogStreamer.targetBinlogPosition
 
-	status.Throttled = f.Throttler.Throttled()
+	status.MigrationThrottled = f.MigrationThrottler.Throttled()
+	status.ReplicationThrottled = f.ReplicationThrottler.Throttled()
+	status.Throttled = status.MigrationThrottled || status.ReplicationThrottled
 
 	// Getting all table statuses
 	status.TableStatuses = make([]*TableStatusDeprecated, 0, len(f.Tables))

--- a/test/go/data_iterator_test.go
+++ b/test/go/data_iterator_test.go
@@ -28,7 +28,7 @@ func (this *DataIteratorTestSuite) SetupTest() {
 	sourceDb := this.Ferry.SourceDB
 	config := this.Ferry.Config
 	errorHandler := this.Ferry.ErrorHandler
-	throttler := this.Ferry.Throttler
+	throttler := this.Ferry.MigrationThrottler
 
 	tableFilter := &testhelpers.TestTableFilter{
 		DbsFunc:    testhelpers.DbApplicabilityFilter([]string{testhelpers.TestSchemaName}),

--- a/webui/index.html
+++ b/webui/index.html
@@ -70,7 +70,14 @@
             </tr>
             <tr>
               <th>Throttling</th>
-              <td>{{.Throttled}}</td>
+              <td>
+                {{if .Throttled}}
+                  Migration: {{if .MigrationThrottled}}throttled{{else}}running{{end}},
+                  Replication: {{if .ReplicationThrottled}}throttled{{else}}running{{end}}
+                {{else}}
+                  off
+                {{end}}
+              </td>
             </tr>
             <tr>
               <th>Tables Copied</th>
@@ -134,12 +141,24 @@
           {{end}}
 
           {{if not (eq .OverallState "done")}}
-            <form action="/api/actions/pause" method="POST">
-              <input type="submit" value="Pause" />
-            </form>
-            <form action="/api/actions/unpause" method="POST">
-              <input type="submit" value="Unpause" />
-            </form>
+            {{if .MigrationThrottled}}
+              <form action="/api/actions/unpause?type=migration" method="POST">
+                <input type="submit" value="Unpause Migration" />
+              </form>
+            {{else}}
+              <form action="/api/actions/pause?type=migration" method="POST">
+                <input type="submit" value="Pause Migration" />
+              </form>
+            {{end}}
+            {{if .ReplicationThrottled}}
+              <form action="/api/actions/unpause?type=replication " method="POST">
+                <input type="submit" value="Unpause Replication" />
+              </form>
+            {{else}}
+              <form action="/api/actions/pause?type=replication" method="POST">
+                <input type="submit" value="Pause Replication" />
+              </form>
+            {{end}}
 
             {{if .AutomaticCutover}}
             <form action="/api/actions/cutover?type=manual" method="POST">


### PR DESCRIPTION
This commit introduces the use of two separate throttler instances for
the data migration and data replication. In some cases it may be
important to give priority to one over the other, so pausing the lower
priority task seems useful.