### PR TITLE
Fix handling of GRANT with resource-options

### DIFF
--- a/binlog_writer.go
+++ b/binlog_writer.go
@@ -227,7 +227,10 @@ func (b *BinlogWriter) handleRowsEvent(ev *ReplicationEvent, rowsEvent *replicat
 func (b *BinlogWriter) handleQueryEvent(ev *ReplicationEvent, queryEvent *replication.QueryEvent) ([]DXLEventWrapper, error) {
 	schemaEvents, err := b.queryAnalyzer.ParseSchemaChanges(string(queryEvent.Query), string(queryEvent.Schema))
 	if err != nil {
-		return nil, err
+		if IncrediblyVerboseLogging {
+			b.logger.Warnf("parsing query event failed (%s): %s", err, string(queryEvent.Query))
+		}
+		return nil, fmt.Errorf("parsing query event failed: %s", err)
 	}
 
 	events := make([]DXLEventWrapper, 0)
@@ -307,7 +310,7 @@ func (b *BinlogWriter) handleQueryEvent(ev *ReplicationEvent, queryEvent *replic
 
 func (b *BinlogWriter) handleReplicationEvent(ev *ReplicationEvent) ([]DXLEventWrapper, error) {
 	if IncrediblyVerboseLogging {
-		b.logger.Debugf("Handling replication event: %v", ev)
+		b.logger.Debugf("Handling %T replication event: %v", ev.BinlogEvent.Event, ev)
 	}
 	switch event := ev.BinlogEvent.Event.(type) {
 	case *replication.RowsEvent:

--- a/test/go/query_analyzer_test.go
+++ b/test/go/query_analyzer_test.go
@@ -1,0 +1,54 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/Shopify/ghostferry"
+)
+
+type QueryAnalyzerTestSuite struct {
+	suite.Suite
+	*ghostferry.QueryAnalyzer
+}
+
+func (this *QueryAnalyzerTestSuite) SetupTest() {
+	this.QueryAnalyzer = ghostferry.NewQueryAnalyzer()
+	this.Require().NotNil(this.QueryAnalyzer)
+}
+
+func (this *QueryAnalyzerTestSuite) TestParseInvalidSQL() {
+	events, err := this.QueryAnalyzer.ParseSchemaChanges("this is not sql", "")
+	this.Require().NotNil(err)
+	this.Require().Nil(events)
+}
+
+func (this *QueryAnalyzerTestSuite) TestParseCreateTableStatement() {
+	inputSql := "CREATE TABLE `dbname`.`tablename` (`id` int)"
+	events, err := this.QueryAnalyzer.ParseSchemaChanges(inputSql, "")
+	this.Require().Nil(err)
+	this.Require().Equal(len(events), 1)
+	this.Require().True(events[0].IsSchemaChange)
+	this.Require().Equal(events[0].SchemaStatement, inputSql)
+	this.Require().Equal(events[0].CreatedTable.SchemaName, "dbname")
+	this.Require().Equal(events[0].CreatedTable.TableName, "tablename")
+	this.Require().Equal(events[0].AffectedTable, events[0].CreatedTable)
+	this.Require().Nil(events[0].DeletedTable)
+}
+
+func (this *QueryAnalyzerTestSuite) TestParseGrantStatement() {
+	events, err := this.QueryAnalyzer.ParseSchemaChanges("GRANT USAGE ON *.* TO `username`@`%`", "")
+	this.Require().Nil(err)
+	this.Require().Equal(len(events), 0)
+}
+
+func (this *QueryAnalyzerTestSuite) TestParseGrantStatementWithMetadata() {
+	events, err := this.QueryAnalyzer.ParseSchemaChanges("GRANT USAGE ON *.* TO `username`@`%` WITH MAX_USER_CONNECTIONS 0 MAX_CONNECTIONS_PER_HOUR 0 MAX_QUERIES_PER_HOUR 0 MAX_UPDATES_PER_HOUR 0", "")
+	this.Require().Nil(err)
+	this.Require().Equal(len(events), 0)
+}
+
+func TestQueryAnalyzer(t *testing.T) {
+	suite.Run(t, new(QueryAnalyzerTestSuite))
+}


### PR DESCRIPTION
The SQL parser we use fails at parsing some GRANT statements:

https://github.com/pingcap/parser/issues/857

We don't need to support them, so this commit hacks around the problem
by detecting the error and ignoring it. This is ugly and must be
fixed... once we have additional cycles.

On the plus side: we add a few trivial (and desperately needed)
unit-tests for the query-analyzer.
