### PR TITLE
Various minor cleanups

### DIFF
--- a/ferry.go
+++ b/ferry.go
@@ -422,6 +422,7 @@ func (f *Ferry) Initialize() (err error) {
 	// we'll regenerate it from the source database, assuming it has not been
 	// changed.
 	if f.StateToResumeFrom == nil || f.StateToResumeFrom.LastKnownTableSchemaCache == nil {
+		f.logger.Debug("loading table schema from source DB")
 		metrics.Measure("LoadTables", nil, 1.0, func() {
 			f.Tables, err = LoadTables(f.SourceDB, f.TableFilter, f.CompressedColumnsForVerification, f.IgnoredColumnsForVerification, f.CascadingPaginationColumnConfig)
 		})

--- a/sharding/test/copy_filter_test.go
+++ b/sharding/test/copy_filter_test.go
@@ -43,7 +43,7 @@ func (t *CopyFilterTestSuite) SetupTest() {
 				{Name: "unrelated_index2", Columns: []string{"data"}},
 			},
 		},
-		PaginationKey: &ghostferry.PaginationKey{[]*schema.TableColumn{&columns[0]}, []int{0}, 0, false},
+		PaginationKey: &ghostferry.PaginationKey{[]*schema.TableColumn{&columns[0]}, []int{0}, 0},
 	}
 	t.paginationKeyCursor, _ = ghostferry.NewPaginationKeyDataFromRow(ghostferry.RowData{t.paginationKeyCursorValue}, t.normalTable.PaginationKey)
 
@@ -55,7 +55,7 @@ func (t *CopyFilterTestSuite) SetupTest() {
 			Columns:   columns,
 			PKColumns: []int{0},
 		},
-		PaginationKey: &ghostferry.PaginationKey{[]*schema.TableColumn{&columns[0]}, []int{0}, 0, false},
+		PaginationKey: &ghostferry.PaginationKey{[]*schema.TableColumn{&columns[0]}, []int{0}, 0},
 	}
 
 	columns = []schema.TableColumn{{Name: "tenant_id", Type: schema.TYPE_NUMBER}}
@@ -66,7 +66,7 @@ func (t *CopyFilterTestSuite) SetupTest() {
 			Columns:   columns,
 			PKColumns: []int{0},
 		},
-		PaginationKey: &ghostferry.PaginationKey{[]*schema.TableColumn{&columns[0]}, []int{0}, 0, false},
+		PaginationKey: &ghostferry.PaginationKey{[]*schema.TableColumn{&columns[0]}, []int{0}, 0},
 	}
 
 	t.filter = &sharding.ShardedCopyFilter{

--- a/table_schema_cache.go
+++ b/table_schema_cache.go
@@ -44,11 +44,6 @@ type PaginationKey struct {
 	// Used only for estimating the position of a particular value within the
 	// range of the pagination
 	MostSignificantColumnIndex int
-
-	// If true, the table should be traversed in descending order. This means
-	// that we allow copying more recent data first (if the key refers to
-	// chronological order of entries)
-	PaginateInAscendingOrder bool
 }
 
 func (k PaginationKey) String() string {
@@ -382,7 +377,6 @@ func (t *TableSchema) paginationKey(cascadingPaginationColumnConfig *CascadingPa
 	paginationKey := &PaginationKey{
 		Columns: paginationKeyColumns,
 		ColumnIndices: paginationKeyColumnIndices,
-		PaginateInAscendingOrder: false,
 	}
 	return paginationKey, err
 }

--- a/test/go/dxl_events_test.go
+++ b/test/go/dxl_events_test.go
@@ -37,7 +37,7 @@ func (this *DMLEventsTestSuite) SetupTest() {
 			Name:    "test_table",
 			Columns: columns,
 		},
-		PaginationKey: &ghostferry.PaginationKey{[]*schema.TableColumn{&columns[0]}, []int{0}, 0, false},
+		PaginationKey: &ghostferry.PaginationKey{[]*schema.TableColumn{&columns[0]}, []int{0}, 0},
 	}
 
 	this.targetTable = &ghostferry.TableSchema{
@@ -46,7 +46,7 @@ func (this *DMLEventsTestSuite) SetupTest() {
 			Name:    "target_table",
 			Columns: columns,
 		},
-		PaginationKey: &ghostferry.PaginationKey{[]*schema.TableColumn{&columns[0]}, []int{0}, 0, false},
+		PaginationKey: &ghostferry.PaginationKey{[]*schema.TableColumn{&columns[0]}, []int{0}, 0},
 	}
 
 	this.tableSchemaCache = map[string]*ghostferry.TableSchema{

--- a/test/go/row_batch_test.go
+++ b/test/go/row_batch_test.go
@@ -36,7 +36,7 @@ func (this *RowBatchTestSuite) SetupTest() {
 			Name:    "test_table",
 			Columns: columns,
 		},
-		PaginationKey: &ghostferry.PaginationKey{[]*schema.TableColumn{&columns[0]}, []int{0}, 0, false},
+		PaginationKey: &ghostferry.PaginationKey{[]*schema.TableColumn{&columns[0]}, []int{0}, 0},
 	}
 
 	this.targetTable = &ghostferry.TableSchema{


### PR DESCRIPTION
This commit does not change the behavior of the code, but it cleans it
up as follows:

- Log a debug statement before loading the DB schema from the source DB.
  Since we just pass a DB handle, nothing ever logged what we are
  analyzing.
- Remove the last written primary key _values_ when logging that the
  key is updated. This could post table values into logs, which we don't
  want.
- Do not read the DB schema from the target DB when reading the DB state
  from the target DB. We used to do this in the past to handle schema
  discrepancies, but this cannot work... and hence it was removed, but
  we still read the schema for no real reason. This makes the startup
  faster and ensures the schema is consistent in all parts of the code.
- Remove "PaginateInAscendingOrder" from the PaginationKey definition.
  It does not really belong there in the first place, but we also never
  really implemented it, so it was misleading.
