### PR TITLE
Fix bug in status page for missing tables

### DIFF
--- a/status_deprecated.go
+++ b/status_deprecated.go
@@ -59,7 +59,9 @@ type StatusDeprecated struct {
 }
 
 func getPaginationColumnName(table *TableSchema) (paginationKeyName string) {
-	if table.PaginationKey == nil {
+	if table == nil {
+		paginationKeyName = "n/a (unknown table)"
+	} else if table.PaginationKey == nil {
 		paginationKeyName = "not paginated"
 	} else {
 		for i, column := range table.PaginationKey.Columns {


### PR DESCRIPTION
Fix a bug where the table status may contain data about a previously
copied - but since deleted - table that the table schemas collection is
not aware of.

Change-Id: Id7e977ee34890e48d82db34cd58063abfcbcca5f