### PR TITLE
Report Binlog Writer State

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,11 @@ Features/fixes added in this fork include
   this fix has not made it into upstream master yet.
 - support throttling of data migration separately from replication. This allows
   prioritizing the data replication over the copy of old data (or vice-versa).
+- support exposing binlog writer state as part of the status portal as well as
+  a new `/api/health` HTTP endpoint returning status as JSON. This endpoint
+  can also be used for Kubernetes lifeness probes by specifying an allowed
+  maximum value for the state age, returning HTTP-500 if the maximum has been
+  exceeded.
 
 Overview of How it Works
 ------------------------

--- a/ferry.go
+++ b/ferry.go
@@ -124,26 +124,7 @@ func (f *Ferry) NewBinlogStreamer() *BinlogStreamer {
 
 func (f *Ferry) NewBinlogWriter() *BinlogWriter {
 	f.ensureInitialized()
-
-	return &BinlogWriter{
-		DB:               f.TargetDB,
-		DatabaseRewrites: f.Config.DatabaseRewrites,
-		TableRewrites:    f.Config.TableRewrites,
-		Throttler:        f.ReplicationThrottler,
-
-		BatchSize:          f.Config.BinlogEventBatchSize,
-		WriteRetries:       f.Config.DBWriteRetries,
-		ApplySchemaChanges: f.Config.ReplicateSchemaChanges,
-		LockStrategy:       f.Config.LockStrategy,
-
-		ErrorHandler:                f.ErrorHandler,
-		StateTracker:                f.StateTracker,
-		ForceResumeStateUpdatesToDB: f.ForceResumeStateUpdatesToDB,
-
-		CopyFilter:  f.CopyFilter,
-		TableFilter: f.TableFilter,
-		TableSchema: f.Tables,
-	}
+	return NewBinlogWriter(f)
 }
 
 func (f *Ferry) NewBinlogWriterWithoutStateTracker() *BinlogWriter {

--- a/status_deprecated.go
+++ b/status_deprecated.go
@@ -34,6 +34,10 @@ type StatusDeprecated struct {
 	BinlogStreamerLag       time.Duration
 	PaginationKeysPerSecond uint64
 
+	BinlogWriterState      BinlogWriterState
+	BinlogWriterStateTs    time.Time
+	BinlogWriterStateTsAge time.Duration
+
 	AutomaticCutover            bool
 	BinlogStreamerStopRequested bool
 	LastSuccessfulBinlogPos     mysql.Position
@@ -92,6 +96,12 @@ func FetchStatusDeprecated(f *Ferry, v Verifier) *StatusDeprecated {
 		status.TimeTaken = f.DoneTime.Sub(status.StartTime)
 	}
 	status.BinlogStreamerLag = time.Now().Sub(f.BinlogStreamer.lastProcessedEventTime)
+
+	status.BinlogWriterState, status.BinlogWriterStateTs = f.BinlogWriter.GetWriterState()
+	status.BinlogWriterStateTsAge = status.CurrentTime.Sub(status.BinlogWriterStateTs)
+	if status.BinlogWriterStateTsAge < 0 {
+		status.BinlogWriterStateTsAge = time.Duration(0)
+	}
 
 	status.AutomaticCutover = f.Config.AutomaticCutover
 	status.BinlogStreamerStopRequested = f.BinlogStreamer.stopRequested

--- a/webui/index.html
+++ b/webui/index.html
@@ -93,6 +93,10 @@
               {{end}}
             </tr>
             <tr>
+              <th>Binlog Writer State</th>
+                <td>{{.BinlogWriterState}} {{.BinlogWriterStateTsAge}} ago (since {{.BinlogWriterStateTs}})</td>
+            </tr>
+            <tr>
               <th>Automatic Cutover Allowed</th>
               <td>{{.AutomaticCutover}}</td>
             </tr>


### PR DESCRIPTION
To improve monitoring of the ghostferry state, this commit introduces
two new metrics on the binlog writer:
- the "last state": if we are currently receiving events from the
  binlog server, are processing/applying them, or something else
- the last state-change timestamp: when the above state was last set.
  This allows detecting lockups (e.g., if we are stuck receiving updates
  from the binlog server).

The above metrics are integated in the status portal. Additionally we
introduce a new "health" API endpoint in the portal, which exports the
status as JSON.

In addition to the JSON export, we allow specifying a maximum age of the
last-change timestamp, returning an HTTP-500 if the age is exceeded.
This is convenient to use the health API as Kubernetes lifeness probe.