### PR TITLE
Skip DROP PROCEDURE/FUNCTION (#38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ Features/fixes added in this fork include
       renamed, created, or deleted.
     - `GRANT` statements are ignored. These are not part of the schema per-se,
       but it is still worth pointing out.
-    - `CREATE PROCEDURE` and `CREATE FUNCTION` statements are currently not
-      supported and are ignored as part of replication. Likewise, functions
-      or procedures defined on the source before replication is started are
-      not copied to the target DB.
+    - `CREATE PROCEDURE`, `CREATE FUNCTION`, `DROP PROCEDURE`, and ,
+      `DROP FUNCTION` statements are currently not supported and are ignored
+      as part of replication. Likewise, functions or procedures defined on the
+      source before replication is started are not copied to the target DB.
 - support [reading from (read-only) DB replica](https://github.com/Lastline-Inc/ghostferry/issues/22):
   allow using locks within `Ghostferry` (instead of on the source database) to
   avoid race conditions between the data copy and binlog replication. The

--- a/query_analyzer.go
+++ b/query_analyzer.go
@@ -72,14 +72,15 @@ func (q *QueryAnalyzer) ParseSchemaChanges(sqlStatement string, schemaOfStatemen
 		// We really need to extend the parser, but we don't have the cycles
 		// right now, so we hack "support" in here - as we ignore these GRANTs
 		// anyways
-		// Same is true for PROCEDURE CREATion. This one is not as easy as
-		// grants, as we *do* care about them (they are part of the schema),
-		// but same reasoning: marking this as not supported
+		// Same is true for PROCEDURE and FUNCTION creation and dropping. This
+		// one is not as easy as grants, as we *do* care about them (they are
+		// part of the schema), but same reasoning: marking this as not supported
 		tokens := strings.SplitN(strings.TrimSpace(sqlStatement), " ", 4)
 		if len(tokens) >= 2 && strings.ToUpper(tokens[0]) == "GRANT" {
 			return schemaEvents, nil
 		}
-		if len(tokens) >= 3 && strings.ToUpper(tokens[0]) == "CREATE" && (
+		if len(tokens) >= 3 && (
+				strings.ToUpper(tokens[0]) == "CREATE" || strings.ToUpper(tokens[0]) == "DROP") && (
 				strings.ToUpper(tokens[1]) == "PROCEDURE" || strings.ToUpper(tokens[1]) == "FUNCTION" ||
 				// SQL allows an optional "DEFINER=" statement
 				strings.ToUpper(tokens[2]) == "PROCEDURE" || strings.ToUpper(tokens[2]) == "FUNCTION") {

--- a/test/integration/schema_change_test.rb
+++ b/test/integration/schema_change_test.rb
@@ -252,7 +252,9 @@ class SchemaChangeIntegrationTests < GhostferryTestCase
       source_db.query("CREATE PROCEDURE test1(OUT result INT) BEGIN SELECT 1 INTO result; END")
       # unsupported 1b: CREATE PROCEDURE (using a schema name as prefix)
       source_db.query("CREATE PROCEDURE #{DEFAULT_DB}.test2(OUT result INT) BEGIN SELECT 1 INTO result; END")
-      # unsupported 2: GRANT USAGE with metadata
+      # unsupported 2: DROP PROCEDURE (not implemented in the parser at all)
+      source_db.query("DROP PROCEDURE #{DEFAULT_DB}.test2")
+      # unsupported 3: GRANT USAGE with metadata
       #source_db.query("GRANT USAGE ON #{DEFAULT_FULL_TABLE_NAME} TO 'root'@'%' WITH MAX_USER_CONNECTIONS 0 MAX_CONNECTIONS_PER_HOUR 0 MAX_QUERIES_PER_HOUR 0 MAX_UPDATES_PER_HOUR 0")
       # eventually, create a DB to be able to check if we survived schema replication
       source_db.query("CREATE TABLE #{DEFAULT_FULL_TABLE_NAME} (id bigint(20) not null, primary key(id))")


### PR DESCRIPTION
Analogous to earlier commit for #38 but for DROP

Better (but still not good enough) handling of DROP PROCEDURE and
DROP FUNCTION statements. The SQL parser we use does not understand
these statements.

Starting with this commit, we log a warning but continue replication.
The statements are not core to replicating a DB content - although it
may not make the target an acceptable migration target after takeover!
Marking support out-of-scope / known-limitation for now.
