### PR TITLE
Extend handling of GRANT exception to REVOKE (#33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ Features/fixes added in this fork include
     - database/table name rewrites are not supported, as we would need non-
       trivial rewrites of schema changing statements when tables are altered,
       renamed, created, or deleted.
-    - `GRANT` statements are ignored. These are not part of the schema per-se,
-      but it is still worth pointing out.
+    - `GRANT` and `REVOKE` statements are ignored. These are not part of the
+      schema per-se, but it is still worth pointing out.
     - `CREATE PROCEDURE`, `CREATE FUNCTION`, `DROP PROCEDURE`, and ,
       `DROP FUNCTION` statements are currently not supported and are ignored
       as part of replication. Likewise, functions or procedures defined on the

--- a/query_analyzer.go
+++ b/query_analyzer.go
@@ -76,7 +76,8 @@ func (q *QueryAnalyzer) ParseSchemaChanges(sqlStatement string, schemaOfStatemen
 		// one is not as easy as grants, as we *do* care about them (they are
 		// part of the schema), but same reasoning: marking this as not supported
 		tokens := strings.SplitN(strings.TrimSpace(sqlStatement), " ", 4)
-		if len(tokens) >= 2 && strings.ToUpper(tokens[0]) == "GRANT" {
+		if len(tokens) >= 2 && (
+				strings.ToUpper(tokens[0]) == "GRANT" || strings.ToUpper(tokens[0]) == "REVOKE") {
 			return schemaEvents, nil
 		}
 		if len(tokens) >= 3 && (

--- a/test/go/query_analyzer_test.go
+++ b/test/go/query_analyzer_test.go
@@ -49,6 +49,18 @@ func (this *QueryAnalyzerTestSuite) TestParseGrantStatementWithMetadata() {
 	this.Require().Equal(len(events), 0)
 }
 
+func (this *QueryAnalyzerTestSuite) TestParseRevokeStatement() {
+	events, err := this.QueryAnalyzer.ParseSchemaChanges("REVOKE ALL PRIVILEGES FROM 'username'@'%'", "")
+	this.Require().Nil(err)
+	this.Require().Equal(len(events), 0)
+}
+
+func (this *QueryAnalyzerTestSuite) TestParseRevokeStatementWithGrantOption() {
+	events, err := this.QueryAnalyzer.ParseSchemaChanges("REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'username'@'%'", "")
+	this.Require().Nil(err)
+	this.Require().Equal(len(events), 0)
+}
+
 func TestQueryAnalyzer(t *testing.T) {
 	suite.Run(t, new(QueryAnalyzerTestSuite))
 }


### PR DESCRIPTION
See earlier commits working around limitations of the SQL parser
which cause us to fail at parsing some GRANT statements:

https://github.com/pingcap/parser/issues/857

We don't need to support them, so this commit extends the hacks around
the problem by detecting the error and ignoring it. This is ugly and
must be fixed... once we have additional cycles.
