### PR TITLE
Support (var)binary primary keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,10 @@ Features/fixes added in this fork include
   DB, it is possible to replicate from read-only sources where locking is not
   an option (e.g., cloud-SQL).
 - support [non-int primary keys](https://github.com/Lastline-Inc/ghostferry/issues/24):
-  extend `Ghostferry` to support signed/unsigned integers, string, and
-  composite primary keys (that use ints and strings). This vastly reduces the
-  types of tables for which "full copy" is required.  
-  Additionally support iterating over table rows to copy in descending order.
+  extend `Ghostferry` to support signed/unsigned integers, string,
+  binary/varbinary, and composite primary keys (that use ints and strings).
+  This vastly reduces the types of tables for which "full copy" is required.
+  Additionally, support iterating over table rows to copy in descending order.
   This allows reading recent data first if the pagination key reflects
   chronological data.  
   Note that there are a few restrictions/limitations with this:

--- a/table_schema_cache.go
+++ b/table_schema_cache.go
@@ -369,7 +369,9 @@ func (t *TableSchema) paginationKey(cascadingPaginationColumnConfig *CascadingPa
 	}
 
 	for _, column := range paginationKeyColumns {
-		if column.Type != schema.TYPE_NUMBER && column.Type != schema.TYPE_STRING {
+		switch column.Type {
+		case schema.TYPE_NUMBER, schema.TYPE_STRING, schema.TYPE_VARBINARY, schema.TYPE_BINARY:
+		default:
 			return nil, UnsupportedPaginationKeyError(t.Schema, t.Name, column.Name)
 		}
 	}


### PR DESCRIPTION
This commit introduces support for binary and varbinary primary keys (PKs).

This fixes #24
